### PR TITLE
feature: 애플 로그인에서 2번째 로그인부터 이메일 제공 안함에 따른 로그인 로직 변경

### DIFF
--- a/src/main/java/com/ward/ward_server/api/user/entity/SocialLogin.java
+++ b/src/main/java/com/ward/ward_server/api/user/entity/SocialLogin.java
@@ -19,7 +19,7 @@ public class SocialLogin {
     @Column(nullable = false, length = 1000)
     private String providerId;
 
-    @Column(nullable = false)
+    @Column
     private String email;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/ward/ward_server/api/user/repository/SocialLoginRepository.java
+++ b/src/main/java/com/ward/ward_server/api/user/repository/SocialLoginRepository.java
@@ -13,4 +13,8 @@ public interface SocialLoginRepository extends JpaRepository<SocialLogin, Long> 
     Optional<SocialLogin> findByProviderAndProviderIdAndEmail(String provider, String providerId, String email);
 
     boolean existsByProviderAndProviderId(String provider, String providerId);
+
+    Optional<SocialLogin> findByProviderAndProviderId(String provider, String s);
+
+    Optional<SocialLogin> findByEmail(String email);
 }

--- a/src/main/java/com/ward/ward_server/api/user/service/AuthService.java
+++ b/src/main/java/com/ward/ward_server/api/user/service/AuthService.java
@@ -9,6 +9,7 @@ import com.ward.ward_server.api.user.entity.SocialLogin;
 import com.ward.ward_server.api.user.entity.User;
 import com.ward.ward_server.api.user.repository.SocialLoginRepository;
 import com.ward.ward_server.api.user.repository.UserRepository;
+import com.ward.ward_server.global.Object.Constants;
 import com.ward.ward_server.global.exception.ApiException;
 import com.ward.ward_server.global.exception.ExceptionCode;
 import com.ward.ward_server.global.util.ValidationUtil;
@@ -69,9 +70,9 @@ public class AuthService {
                 SocialLogin existingSocialLogin = existingSocialLoginOptional.get();
                 String provider = existingSocialLogin.getProvider();
 
-                if ("kakao".equalsIgnoreCase(provider)) {
+                if (Constants.KAKAO.equalsIgnoreCase(provider)) {
                     throw new ApiException(ExceptionCode.EXISTENT_USER_KAKAO);
-                } else if ("apple".equalsIgnoreCase(provider)) {
+                } else if (Constants.APPLE.equalsIgnoreCase(provider)) {
                     throw new ApiException(ExceptionCode.EXISTENT_USER_APPLE);
                 } else {
                     throw new ApiException(ExceptionCode.EXISTENT_USER);

--- a/src/main/java/com/ward/ward_server/global/Object/Constants.java
+++ b/src/main/java/com/ward/ward_server/global/Object/Constants.java
@@ -6,4 +6,6 @@ public class Constants {
     public static final DateTimeFormatter FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
     public static final int HOME_PAGE_SIZE = 10;
     public static final int API_PAGE_SIZE = 30;
+    public static final String KAKAO = "kakao";
+    public static final String APPLE = "apple";
 }

--- a/src/main/java/com/ward/ward_server/global/exception/ExceptionCode.java
+++ b/src/main/java/com/ward/ward_server/global/exception/ExceptionCode.java
@@ -19,11 +19,13 @@ public enum ExceptionCode {
     DUPLICATE_NICKNAME(5206, "이미 사용 중인 닉네임입니다."),
     INVALID_REFRESH_TOKEN(5207, "유효하지 않은 리프레시 토큰입니다."),
     NON_EXISTENT_USER(5208, "존재하지 않는 회원입니다. 회원가입이 필요합니다."),
-    EXISTENT_USER(5209,"해당 이메일은 다른 소셜 로그인으로 가입한 내역이 존재합니다. 계정 통합 의사를 확인 후 기존 소셜로그인 진행 후 통합합니다."),
     EXISTENT_USER_AT_REGISTER(5210,"해당 이메일로 가입한 내역이 존재합니다. 가입한 이메일로 로그인을 진행해야합니다."),
     EXISTENT_USER_AT_REGISTER_WITH_PROVIDER_PID(5211,"해당 provider+providerId에 해당하는 회원이 존재합니다. 로그인을 진행해야합니다."),
     EXISTENT_USER_AT_ADD_SOCIAL_ACCOUNT(5212,"해당 provider+providerId에 해당하는 회원이 존재합니다. 기존 연동된 계정에서 해제 후 다시 연동 시도바랍니다."),
     TOKEN_REFRESH_FAILURE(5213, "토큰 갱신에 실패하였습니다."),
+    EXISTENT_USER(5214,"해당 이메일은 다른 소셜 로그인으로 가입한 내역이 존재합니다. 계정 통합 의사를 확인 후 기존 소셜로그인 진행 후 통합합니다."),
+    EXISTENT_USER_KAKAO(5215,"해당 이메일은 카카오 계정으로 가입한 내역이 존재합니다. 기존 계정으로 로그인 안내 혹은 계정 통합 의사를 확인 후 기존 소셜 로그인 진행 후 통합합니다."),
+    EXISTENT_USER_APPLE(5216,"해당 이메일은 애플 계정으로 가입한 내역이 존재합니다. 기존 계정으로 로그인 안내 혹은 계정 통합 의사를 확인 후 기존 소셜 로그인 진행 후 통합합니다."),
 
     //아이템
     ITEM_NOT_FOUND(5300, "상품을 찾을 수 없습니다."),


### PR DESCRIPTION
email 이 없는 경우에는 provider+provider 로 사용자 정보를 찾아와서 해결
social_login 테이블에 email 에 nullable=true 삭제
최초 가입 시에는 email 제공해주기 때문에 결국에 큰 차이 없음.