### PR TITLE
매 정각 상품 조회순 Top10 조회 API 개발

### DIFF
--- a/src/main/java/com/ward/ward_server/api/item/controller/ItemController.java
+++ b/src/main/java/com/ward/ward_server/api/item/controller/ItemController.java
@@ -3,8 +3,12 @@ package com.ward.ward_server.api.item.controller;
 import com.ward.ward_server.api.item.dto.ItemDetailResponse;
 import com.ward.ward_server.api.item.dto.ItemRequest;
 import com.ward.ward_server.api.item.dto.ItemSimpleResponse;
+import com.ward.ward_server.api.item.dto.ItemTop10Response;
+import com.ward.ward_server.api.item.entity.ItemViewCount;
+import com.ward.ward_server.api.item.entity.enumtype.Category;
 import com.ward.ward_server.api.item.entity.enumtype.ItemSort;
 import com.ward.ward_server.api.item.service.ItemService;
+import com.ward.ward_server.api.item.service.TopItemsCacheService;
 import com.ward.ward_server.api.user.auth.security.CustomUserDetails;
 import com.ward.ward_server.global.exception.ApiException;
 import com.ward.ward_server.global.response.ApiResponse;
@@ -13,6 +17,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.ward.ward_server.global.response.ApiResponseMessage.*;
 
@@ -22,6 +27,7 @@ import static com.ward.ward_server.global.response.ApiResponseMessage.*;
 public class ItemController {
 
     private final ItemService itemService;
+    private final TopItemsCacheService topItemsCacheService;
 
     @PostMapping
     public ApiResponse<ItemDetailResponse> createItem(@RequestBody ItemRequest request) throws ApiException {
@@ -39,6 +45,20 @@ public class ItemController {
     public ApiResponse<List<ItemSimpleResponse>> getItem10List(@AuthenticationPrincipal CustomUserDetails principal,
                                                                @RequestParam ItemSort sort) {
         return ApiResponse.ok(ITEM_LIST_LOAD_SUCCESS, itemService.getItem10List(principal.getUserId(), sort));
+    }
+
+    @GetMapping("/top10")
+    public ApiResponse<List<ItemTop10Response>> getTop10ItemsByCategory(@RequestParam("category") String category) {
+        Category itemCategory = Category.ofText(category);
+        List<ItemViewCount> topItems = topItemsCacheService.getTopItemsByCategory(itemCategory);
+        List<ItemTop10Response> topItemsResponse = topItems.stream()
+                .map(itemViewCount -> new ItemTop10Response(
+                        itemViewCount.getItem().getId().intValue(),
+                        itemViewCount.getItem().getMainImage(),
+                        itemViewCount.getItem().getBrand().getKoreanName(),
+                        itemViewCount.getItem().getKoreanName()))
+                .collect(Collectors.toList());
+        return ApiResponse.ok(REALTIME_TOP10_LOAD_SUCCESS, topItemsResponse);
     }
 
     @PatchMapping

--- a/src/main/java/com/ward/ward_server/api/item/dto/ItemTop10Response.java
+++ b/src/main/java/com/ward/ward_server/api/item/dto/ItemTop10Response.java
@@ -1,0 +1,9 @@
+package com.ward.ward_server.api.item.dto;
+
+public record ItemTop10Response(
+        int rank,
+        String mainImage,
+        String brandName,
+        String koreanName
+) {
+}

--- a/src/main/java/com/ward/ward_server/api/item/entity/ItemViewCount.java
+++ b/src/main/java/com/ward/ward_server/api/item/entity/ItemViewCount.java
@@ -1,0 +1,41 @@
+package com.ward.ward_server.api.item.entity;
+
+import com.ward.ward_server.api.item.entity.enumtype.Category;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ItemViewCount {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Category category;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id", nullable = false)
+    private Item item;
+
+    @Column(nullable = false)
+    private Long viewCount;
+
+    @Column(nullable = false)
+    private LocalDateTime calculatedAt;
+
+    @Builder
+    public ItemViewCount(Category category, Item item, Long viewCount, LocalDateTime calculatedAt) {
+        this.category = category;
+        this.item = item;
+        this.viewCount = viewCount;
+        this.calculatedAt = calculatedAt;
+    }
+}

--- a/src/main/java/com/ward/ward_server/api/item/entity/ItemViewCount.java
+++ b/src/main/java/com/ward/ward_server/api/item/entity/ItemViewCount.java
@@ -38,4 +38,8 @@ public class ItemViewCount {
         this.viewCount = viewCount;
         this.calculatedAt = calculatedAt;
     }
+
+    public void increaseViewCount() {
+        this.viewCount += 1;
+    }
 }

--- a/src/main/java/com/ward/ward_server/api/item/repository/ItemViewCountRepository.java
+++ b/src/main/java/com/ward/ward_server/api/item/repository/ItemViewCountRepository.java
@@ -1,0 +1,7 @@
+package com.ward.ward_server.api.item.repository;
+
+import com.ward.ward_server.api.item.entity.ItemViewCount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ItemViewCountRepository extends JpaRepository<ItemViewCount, Long> {
+}

--- a/src/main/java/com/ward/ward_server/api/item/repository/ItemViewCountRepository.java
+++ b/src/main/java/com/ward/ward_server/api/item/repository/ItemViewCountRepository.java
@@ -1,7 +1,12 @@
 package com.ward.ward_server.api.item.repository;
 
+import com.ward.ward_server.api.item.entity.Item;
 import com.ward.ward_server.api.item.entity.ItemViewCount;
+import com.ward.ward_server.api.item.entity.enumtype.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ItemViewCountRepository extends JpaRepository<ItemViewCount, Long> {
+    Optional<ItemViewCount> findByItemAndCategory(Item item, Category category);
 }

--- a/src/main/java/com/ward/ward_server/api/item/scheduler/ItemViewCountScheduler.java
+++ b/src/main/java/com/ward/ward_server/api/item/scheduler/ItemViewCountScheduler.java
@@ -1,0 +1,59 @@
+package com.ward.ward_server.api.item.scheduler;
+
+import com.ward.ward_server.api.item.entity.Item;
+import com.ward.ward_server.api.item.entity.ItemViewCount;
+import com.ward.ward_server.api.item.entity.enumtype.Category;
+import com.ward.ward_server.api.item.repository.ItemRepository;
+import com.ward.ward_server.api.item.repository.ItemViewCountRepository;
+import com.ward.ward_server.api.item.service.TopItemsCacheService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ItemViewCountScheduler {
+
+    private final ItemRepository itemRepository;
+    private final ItemViewCountRepository itemViewCountRepository;
+    private final TopItemsCacheService topItemsCacheService;
+
+    @Scheduled(cron = "0 0 * * * *") // 매 정각마다 실행
+    public void updateViewCounts() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime startTime = now.minusDays(1);
+
+        List<Item> items = itemRepository.findAll();
+
+        // 그룹별 아이템 조회수 집계
+        Map<Category, Map<Long, Long>> viewCountMap = items.stream()
+                .collect(Collectors.groupingBy(Item::getCategory,
+                        Collectors.groupingBy(Item::getId, Collectors.summingLong(Item::getViewCount))));
+
+        // ItemViewCount 테이블 업데이트
+        viewCountMap.forEach((category, itemViewCounts) -> {
+            itemViewCounts.forEach((itemId, viewCount) -> {
+                Item item = itemRepository.findById(itemId).orElseThrow();
+                ItemViewCount itemViewCount = ItemViewCount.builder()
+                        .category(category)
+                        .item(item)
+                        .viewCount(viewCount)
+                        .calculatedAt(now)
+                        .build();
+                itemViewCountRepository.save(itemViewCount);
+            });
+        });
+
+        // 캐시 업데이트
+        topItemsCacheService.updateTopItemsCache(viewCountMap);
+
+        log.info("View counts updated at {}", now);
+    }
+}

--- a/src/main/java/com/ward/ward_server/api/item/service/TopItemsCacheService.java
+++ b/src/main/java/com/ward/ward_server/api/item/service/TopItemsCacheService.java
@@ -1,0 +1,37 @@
+package com.ward.ward_server.api.item.service;
+
+import com.ward.ward_server.api.item.entity.ItemViewCount;
+import com.ward.ward_server.api.item.entity.enumtype.Category;
+import com.ward.ward_server.api.item.repository.ItemViewCountRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TopItemsCacheService {
+
+    private final ItemViewCountRepository itemViewCountRepository;
+    private Map<Category, List<ItemViewCount>> topItemsCache = new HashMap<>();
+
+    public void updateTopItemsCache(Map<Category, Map<Long, Long>> viewCountMap) {
+        for (Map.Entry<Category, Map<Long, Long>> entry : viewCountMap.entrySet()) {
+            Category category = entry.getKey();
+            Map<Long, Long> itemViewCounts = entry.getValue();
+
+            List<ItemViewCount> topItems = itemViewCounts.entrySet().stream()
+                    .sorted(Map.Entry.<Long, Long>comparingByValue().reversed())
+                    .limit(10)
+                    .map(itemEntry -> itemViewCountRepository.findById(itemEntry.getKey()).orElseThrow())
+                    .collect(Collectors.toList());
+
+            topItemsCache.put(category, topItems);
+        }
+    }
+
+    public List<ItemViewCount> getTopItemsByCategory(Category category) {
+        return topItemsCache.getOrDefault(category, Collections.emptyList());
+    }
+}

--- a/src/main/java/com/ward/ward_server/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/ward/ward_server/global/config/WebSecurityConfig.java
@@ -40,6 +40,7 @@ public class WebSecurityConfig {
                         .requestMatchers("/auth/logout").authenticated()
                         .requestMatchers("/","/auth/**", "/v1/wc/**","/releaseInfos/**").permitAll()
                         .requestMatchers("/items/details").hasAnyRole("USER", "ADMIN")
+                        .requestMatchers("/items/top10").permitAll()
                         .requestMatchers(HttpMethod.GET, "/items").hasAnyRole("USER", "ADMIN")
                         .requestMatchers("/items/**").hasRole("ADMIN")
                         .requestMatchers("/admin/**").hasRole("ADMIN")

--- a/src/main/java/com/ward/ward_server/global/response/ApiResponseMessage.java
+++ b/src/main/java/com/ward/ward_server/global/response/ApiResponseMessage.java
@@ -25,6 +25,7 @@ public enum ApiResponseMessage {
     ITEM_DELETE_SUCCESS("상품 삭제에 성공하였습니다."),
     ITEM_LIST_LOAD_SUCCESS("상품 목록 조회에 성공하였습니다."),
     ITEM_PAGE_LOAD_SUCCESS("상품 페이지 조회에 성공하였습니다."),
+    REALTIME_TOP10_LOAD_SUCCESS("실시간 Top10 조회에 성공하였습니다."),
     //브랜드
     BRAND_CREATE_SUCCESS("브랜드 등록에 성공하였습니다."),
     BRAND_TOP10_WITH_ITEM_LOAD_SUCCESS("top10 브랜드와 상품 목록 조회에 성공하였습니다."),


### PR DESCRIPTION
매 정각마다 상품의 조회수를 집계하여 조회순 Top10 상품을 제공하는 API를 추가합니다.

### 주요 변경 사항
1. ItemViewCount 엔티티 추가: 상품별 조회수를 기록하기 위한 엔티티를 추가했습니다.
2. ItemService 클래스 수정: 상품 조회 시 Item과 ItemViewCount의 조회수를 증가시키는 로직을 추가했습니다.
3. TopItemsCacheService 클래스 추가: 조회수 기준 Top10 상품을 캐싱하고 제공하는 서비스를 추가했습니다.
4. ItemViewCountScheduler 클래스 추가: 매 정각마다 ItemViewCount 테이블을 업데이트하는 스케줄러를 추가했습니다.
5. ItemController 클래스 수정: 새로운 Top10 조회 API 엔드포인트를 추가했습니다.

### 추가 설명
1. 조회수 집계: ItemService에서 조회수를 증가시키며, ItemViewCount 엔티티의 viewCount 필드도 함께 증가시킵니다.
2. 정기 스케줄링: ItemViewCountScheduler 클래스에서 매 정각마다 ItemViewCount 테이블을 업데이트하여 정확한 조회수 집계를 보장합니다.
3. 캐시 서비스: TopItemsCacheService 클래스에서 매 정각마다 업데이트된 조회수 데이터를 기반으로 캐시를 관리하며, API 요청 시 빠르게 응답할 수 있도록 합니다.

제안 주신 매 시각마다 이전 조회수와 비교하는 방식은 "모든" 아이템의 조회수를 매 시각마다 "전부" 비교해야함으로 조회수 추가가 없는 상품까지 매번 모두 비교해야하기 때문에 성능 저하가 우려됩니다. 따라서 현재 방식과 같이 조회수가 찍히는 상품에 한 해서만 조회수를 비교하여 가져올 수 있도록 개발하였습니다.