### PR TITLE
Feat: 카테고리별, 정렬별 상품 목록/페이지 조회 API

### DIFF
--- a/src/main/java/com/ward/ward_server/api/item/controller/ItemController.java
+++ b/src/main/java/com/ward/ward_server/api/item/controller/ItemController.java
@@ -9,10 +9,12 @@ import com.ward.ward_server.api.item.entity.enums.Category;
 import com.ward.ward_server.api.item.service.ItemService;
 import com.ward.ward_server.api.item.service.TopItemsCacheService;
 import com.ward.ward_server.api.user.auth.security.CustomUserDetails;
+import com.ward.ward_server.global.Object.PageResponse;
 import com.ward.ward_server.global.Object.enums.HomeSort;
 import com.ward.ward_server.global.exception.ApiException;
 import com.ward.ward_server.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.checkerframework.checker.index.qual.Positive;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -40,11 +42,19 @@ public class ItemController {
         return ApiResponse.ok(ITEM_DETAIL_LOAD_SUCCESS, itemService.getItem(itemId));
     }
 
-    @GetMapping
+    @GetMapping("/home")
     public ApiResponse<List<ItemSimpleResponse>> getItem10List(@AuthenticationPrincipal CustomUserDetails principal,
                                                                @RequestParam("sort") HomeSort sort,
                                                                @RequestParam("category") Category category) {
         return ApiResponse.ok(ITEM_LIST_LOAD_SUCCESS, itemService.getItem10List(principal.getUserId(), sort, category));
+    }
+
+    @GetMapping
+    public ApiResponse<PageResponse<ItemSimpleResponse>> getItemPage(@AuthenticationPrincipal CustomUserDetails principal,
+                                                                     @RequestParam("sort") HomeSort sort,
+                                                                     @RequestParam("category") Category category,
+                                                                     @Positive @RequestParam("page") int page) {
+        return ApiResponse.ok(ITEM_LIST_LOAD_SUCCESS, itemService.getItemPage(principal.getUserId(), sort, category, page - 1));
     }
 
     @GetMapping("/top10")

--- a/src/main/java/com/ward/ward_server/api/item/controller/ItemController.java
+++ b/src/main/java/com/ward/ward_server/api/item/controller/ItemController.java
@@ -41,9 +41,10 @@ public class ItemController {
     }
 
     @GetMapping
-    public ApiResponse<List<ItemSimpleResponse>> getItem10ListSortedForHomeView(@AuthenticationPrincipal CustomUserDetails principal,
-                                                                                @RequestParam("sort") HomeSort sort) {
-        return ApiResponse.ok(ITEM_LIST_LOAD_SUCCESS, itemService.getItem10ListSortedForHomeView(principal.getUserId(), sort));
+    public ApiResponse<List<ItemSimpleResponse>> getItem10List(@AuthenticationPrincipal CustomUserDetails principal,
+                                                               @RequestParam("sort") HomeSort sort,
+                                                               @RequestParam("category") Category category) {
+        return ApiResponse.ok(ITEM_LIST_LOAD_SUCCESS, itemService.getItem10List(principal.getUserId(), sort, category));
     }
 
     @GetMapping("/top10")

--- a/src/main/java/com/ward/ward_server/api/item/dto/ItemSimpleResponse.java
+++ b/src/main/java/com/ward/ward_server/api/item/dto/ItemSimpleResponse.java
@@ -11,6 +11,6 @@ public record ItemSimpleResponse(
         long brandId,
         String brandKoreanName,
         String brandEnglishName,
-        boolean wished
+        boolean isWished
 ) {
 }

--- a/src/main/java/com/ward/ward_server/api/item/repository/query/ItemQueryRepository.java
+++ b/src/main/java/com/ward/ward_server/api/item/repository/query/ItemQueryRepository.java
@@ -1,18 +1,12 @@
 package com.ward.ward_server.api.item.repository.query;
 
 import com.ward.ward_server.api.item.dto.ItemSimpleResponse;
+import com.ward.ward_server.api.item.entity.enums.Category;
+import com.ward.ward_server.global.Object.enums.HomeSort;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ItemQueryRepository {
-    List<ItemSimpleResponse> getDueTodayItemOrdered(long userId, LocalDateTime date);
-
-    List<ItemSimpleResponse> getReleaseTodayItemOrdered(long userId, LocalDateTime date);
-
-    List<ItemSimpleResponse> getReleaseWishItemOrdered(long userId, LocalDateTime date);
-
-    List<ItemSimpleResponse> getJustConfirmReleaseItemOrdered(long userId, LocalDateTime date);
-
-    List<ItemSimpleResponse> getRegisterTodayItemOrdered(long userId, LocalDateTime date);
+    List<ItemSimpleResponse> getHomeSortList(Long userId, LocalDateTime now, Category category, HomeSort homeSort);
 }

--- a/src/main/java/com/ward/ward_server/api/item/repository/query/ItemQueryRepository.java
+++ b/src/main/java/com/ward/ward_server/api/item/repository/query/ItemQueryRepository.java
@@ -3,10 +3,14 @@ package com.ward.ward_server.api.item.repository.query;
 import com.ward.ward_server.api.item.dto.ItemSimpleResponse;
 import com.ward.ward_server.api.item.entity.enums.Category;
 import com.ward.ward_server.global.Object.enums.HomeSort;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ItemQueryRepository {
     List<ItemSimpleResponse> getHomeSortList(Long userId, LocalDateTime now, Category category, HomeSort homeSort);
+
+    Page<ItemSimpleResponse> getHomeSortPage(Long userId, LocalDateTime now, Category category, HomeSort homeSort, Pageable pageable);
 }

--- a/src/main/java/com/ward/ward_server/api/item/repository/query/ItemQueryRepositoryImpl.java
+++ b/src/main/java/com/ward/ward_server/api/item/repository/query/ItemQueryRepositoryImpl.java
@@ -1,12 +1,17 @@
 package com.ward.ward_server.api.item.repository.query;
 
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.DateTimePath;
 import com.querydsl.core.types.dsl.DateTimeTemplate;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.ward.ward_server.api.item.dto.ItemSimpleResponse;
+import com.ward.ward_server.api.item.entity.enums.Category;
+import com.ward.ward_server.global.Object.enums.HomeSort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -26,9 +31,8 @@ import static com.ward.ward_server.global.Object.Constants.HOME_PAGE_SIZE;
 public class ItemQueryRepositoryImpl implements ItemQueryRepository {
     private final JPAQueryFactory queryFactory;
 
-    public List<ItemSimpleResponse> getDueTodayItemOrdered(long userId, LocalDateTime now) {
-        DateTimeTemplate<LocalDateTime> nowDateTime = Expressions.dateTimeTemplate(LocalDateTime.class, "{0}", now);
-        //마감일 = 오늘, 발매일 < 지금 < 마감일, 정렬은 마감일 오름차순
+    public List<ItemSimpleResponse> getHomeSortList(Long userId, LocalDateTime now, Category category, HomeSort homeSort) {
+        Set<Long> wishItemIds = wishItemIdListByUser(userId);
         List<Tuple> result = queryFactory.select(
                         item.id,
                         item.koreanName,
@@ -41,98 +45,54 @@ public class ItemQueryRepositoryImpl implements ItemQueryRepository {
                 ).from(releaseInfo)
                 .leftJoin(releaseInfo.item, item)
                 .leftJoin(item.brand, brand)
-                .where(isSameDay(now, releaseInfo.dueDate), nowDateTime.between(releaseInfo.releaseDate, releaseInfo.dueDate))
-                .orderBy(releaseInfo.dueDate.asc())
+                .where(getSortCondition(homeSort, now, wishItemIds), getCategoryCondition(category))
+                .orderBy(getSortOrder(homeSort))
                 .limit(HOME_PAGE_SIZE)
                 .fetch();
-        return itemSimpleResponseList(userId, result);
+        return itemSimpleResponseList(result, wishItemIds);
     }
 
-    public List<ItemSimpleResponse> getReleaseTodayItemOrdered(long userId, LocalDateTime now) {
+    private BooleanBuilder getSortCondition(HomeSort homeSort, LocalDateTime now, Set<Long> wishItemIds) {
         DateTimeTemplate<LocalDateTime> nowDateTime = Expressions.dateTimeTemplate(LocalDateTime.class, "{0}", now);
-        //발매일 < 지금 < 마감일, 정렬은 마감일 오름차순
-        List<Tuple> result = queryFactory.select(
-                        item.id,
-                        item.koreanName,
-                        item.englishName,
-                        item.code,
-                        item.mainImage,
-                        brand.id,
-                        brand.koreanName,
-                        brand.englishName
-                ).from(releaseInfo)
-                .leftJoin(releaseInfo.item, item)
-                .leftJoin(item.brand, brand)
-                .where(nowDateTime.between(releaseInfo.releaseDate, releaseInfo.dueDate))
-                .orderBy(releaseInfo.dueDate.asc())
-                .limit(HOME_PAGE_SIZE)
-                .fetch();
-        return itemSimpleResponseList(userId, result);
+        BooleanBuilder builder = new BooleanBuilder();
+
+        switch (homeSort) {
+            case DUE_TODAY -> {
+                //마감일 = 오늘, 발매일 < 지금 < 마감일, 정렬은 마감일 오름차순
+                builder.and(isSameDay(now, releaseInfo.dueDate))
+                        .and(nowDateTime.between(releaseInfo.releaseDate, releaseInfo.dueDate));
+            }
+            case RELEASE_NOW -> {
+                //발매일 < 지금 < 마감일, 정렬은 마감일 오름차순
+                builder.and(nowDateTime.between(releaseInfo.releaseDate, releaseInfo.dueDate));
+            }
+            case RELEASE_WISH -> {
+                //발매일 < 지금 < 마감일, 사용자의 관심 상품, 정렬은 마감일 오름차순
+                builder.and(nowDateTime.between(releaseInfo.releaseDate, releaseInfo.dueDate))
+                        .and(item.id.in(wishItemIds));
+            }
+            case RELEASE_CONFIRM -> {
+                //지금 < 발매일, 정렬은 발매일 오름차순
+                builder.and(nowDateTime.before(releaseInfo.releaseDate));
+            }
+            default -> {
+                //생성일 = 지금, 정렬은 생성일 오름차순
+                builder.and(isSameDay(now, releaseInfo.createdAt));
+            }
+        }
+        return builder;
     }
 
-    public List<ItemSimpleResponse> getReleaseWishItemOrdered(long userId, LocalDateTime now) {
-        DateTimeTemplate<LocalDateTime> nowDateTime = Expressions.dateTimeTemplate(LocalDateTime.class, "{0}", now);
-        //발매일 < 지금 < 마감일, 사용자의 관심 상품, 정렬은 마감일 오름차순
-        List<Tuple> result = queryFactory.select(
-                        item.id,
-                        item.koreanName,
-                        item.englishName,
-                        item.code,
-                        item.mainImage,
-                        brand.id,
-                        brand.koreanName,
-                        brand.englishName
-                ).from(releaseInfo)
-                .leftJoin(releaseInfo.item, item)
-                .leftJoin(item.brand, brand)
-                .where(item.id.in(wishItemIdListByUser(userId)),
-                        nowDateTime.between(releaseInfo.releaseDate, releaseInfo.dueDate))
-                .orderBy(releaseInfo.dueDate.asc())
-                .limit(HOME_PAGE_SIZE)
-                .fetch();
-        return itemSimpleResponseList(userId, result);
+    private BooleanExpression getCategoryCondition(Category category) {
+        return category == Category.ALL ? null : item.category.eq(category);
     }
 
-    public List<ItemSimpleResponse> getJustConfirmReleaseItemOrdered(long userId, LocalDateTime now) {
-        DateTimeTemplate<LocalDateTime> nowDateTime = Expressions.dateTimeTemplate(LocalDateTime.class, "{0}", now);
-        //지금 < 발매일, 정렬은 발매일 오름차순
-        List<Tuple> result = queryFactory.select(
-                        item.id,
-                        item.koreanName,
-                        item.englishName,
-                        item.code,
-                        item.mainImage,
-                        brand.id,
-                        brand.koreanName,
-                        brand.englishName
-                ).from(releaseInfo)
-                .leftJoin(releaseInfo.item, item)
-                .leftJoin(item.brand, brand)
-                .where(nowDateTime.before(releaseInfo.releaseDate))
-                .orderBy(releaseInfo.releaseDate.asc())
-                .limit(HOME_PAGE_SIZE)
-                .fetch();
-        return itemSimpleResponseList(userId, result);
-    }
-
-    public List<ItemSimpleResponse> getRegisterTodayItemOrdered(long userId, LocalDateTime now) {
-        //생성일 = 지금, 발매일 = null, 정렬은 생성일 오름차순
-        List<Tuple> result = queryFactory.select(
-                        item.id,
-                        item.koreanName,
-                        item.englishName,
-                        item.code,
-                        item.mainImage,
-                        brand.id,
-                        brand.koreanName,
-                        brand.englishName
-                ).from(item)
-                .leftJoin(item.brand, brand)
-                .where(isSameDay(now, item.createdAt))
-                .orderBy(item.createdAt.asc())
-                .limit(HOME_PAGE_SIZE)
-                .fetch();
-        return itemSimpleResponseList(userId, result);
+    private OrderSpecifier<LocalDateTime> getSortOrder(HomeSort homeSort) {
+        return switch (homeSort) {
+            case REGISTER_TODAY -> new OrderSpecifier<>(Order.ASC, releaseInfo.createdAt);
+            case RELEASE_CONFIRM -> new OrderSpecifier<>(Order.ASC, releaseInfo.releaseDate);
+            default -> new OrderSpecifier<>(Order.ASC, releaseInfo.dueDate);
+        };
     }
 
     private BooleanExpression isSameDay(LocalDateTime dateTime, DateTimePath<LocalDateTime> datePath) {
@@ -142,15 +102,17 @@ public class ItemQueryRepositoryImpl implements ItemQueryRepository {
                 .and(Expressions.numberTemplate(Integer.class, "DAY({0})", datePath).eq(dateTime.getDayOfMonth()));
     }
 
-    private Set<Long> wishItemIdListByUser(long userId) {
-        return new HashSet<>(queryFactory.select(wishItem.item.id)
-                .from(wishItem)
-                .where(wishItem.user.id.eq(userId))
-                .fetch());
+    private Set<Long> wishItemIdListByUser(Long userId) {
+        if (userId == null) {
+            return new HashSet<>();
+        }
+        return new HashSet<>(
+                queryFactory.select(wishItem.item.id)
+                        .from(wishItem)
+                        .where(wishItem.user.id.eq(userId)).fetch());
     }
 
-    private List<ItemSimpleResponse> itemSimpleResponseList(long userId, List<Tuple> tuples) {
-        final Set<Long> wishItemIdList = wishItemIdListByUser(userId);
+    private List<ItemSimpleResponse> itemSimpleResponseList(List<Tuple> tuples, Set<Long> wishItemIds) {
         return tuples.stream()
                 .map(e -> new ItemSimpleResponse(
                         e.get(item.id),
@@ -161,7 +123,7 @@ public class ItemQueryRepositoryImpl implements ItemQueryRepository {
                         e.get(brand.id),
                         e.get(brand.koreanName),
                         e.get(brand.englishName),
-                        wishItemIdList.contains(e.get(item.id))))
+                        wishItemIds.contains(e.get(item.id))))
                 .toList();
     }
 }

--- a/src/main/java/com/ward/ward_server/api/item/repository/query/ItemQueryRepositoryImpl.java
+++ b/src/main/java/com/ward/ward_server/api/item/repository/query/ItemQueryRepositoryImpl.java
@@ -41,6 +41,8 @@ public class ItemQueryRepositoryImpl implements ItemQueryRepository {
                 .where(getSortCondition(homeSort, now, wishItemIds), getCategoryCondition(category))
                 .fetch();
 
+        log.debug("tuples 검사 {}", tuples);
+
         Map<Long, LocalDateTime> itemIdAndDateMap = tuples.stream()
                 .collect(Collectors.groupingBy(
                         tuple -> tuple.get(0, Long.class),
@@ -48,6 +50,8 @@ public class ItemQueryRepositoryImpl implements ItemQueryRepository {
                                 Collectors.mapping(tuple -> tuple.get(1, LocalDateTime.class), Collectors.toList()),
                                 dateList -> dateList.stream().min(Comparator.naturalOrder()).orElse(null))
                 ));
+
+        log.debug("map 검사 {}", itemIdAndDateMap.size());
 
         List<Long> top10 = itemIdAndDateMap.entrySet().stream()
                 .sorted(Map.Entry.comparingByValue())

--- a/src/main/java/com/ward/ward_server/api/item/service/ItemService.java
+++ b/src/main/java/com/ward/ward_server/api/item/service/ItemService.java
@@ -92,12 +92,14 @@ public class ItemService {
 
     @Transactional(readOnly = true)
     public List<ItemSimpleResponse> getItem10List(Long userId, HomeSort homeSort, Category category) {
-        return itemRepository.getHomeSortList(userId, LocalDateTime.now(), category, homeSort);
+        //HACK DB 시간 설정 전까지는 -9시간으로 비교해야 한다.
+        return itemRepository.getHomeSortList(userId, LocalDateTime.now().minusHours(9), category, homeSort);
     }
 
     @Transactional(readOnly = true)
     public PageResponse<ItemSimpleResponse> getItemPage(Long userId, HomeSort homeSort, Category category, int page) {
-        Page<ItemSimpleResponse> itemPageInfo = itemRepository.getHomeSortPage(userId, LocalDateTime.now(), category, homeSort, PageRequest.of(page, API_PAGE_SIZE));
+        //HACK DB 시간 설정 전까지는 -9시간으로 비교해야 한다.
+        Page<ItemSimpleResponse> itemPageInfo = itemRepository.getHomeSortPage(userId, LocalDateTime.now().minusHours(9), category, homeSort, PageRequest.of(page, API_PAGE_SIZE));
         return new PageResponse<>(itemPageInfo.getContent(), itemPageInfo);
     }
 

--- a/src/main/java/com/ward/ward_server/api/item/service/ItemService.java
+++ b/src/main/java/com/ward/ward_server/api/item/service/ItemService.java
@@ -15,7 +15,6 @@ import com.ward.ward_server.global.Object.enums.HomeSort;
 import com.ward.ward_server.global.exception.ApiException;
 import com.ward.ward_server.global.util.ValidationUtils;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -88,15 +87,9 @@ public class ItemService {
     }
 
     @Transactional(readOnly = true)
-    public List<ItemSimpleResponse> getItem10ListSortedForHomeView(Long userId, HomeSort homeSort) {
+    public List<ItemSimpleResponse> getItem10List(Long userId, HomeSort homeSort, Category category) {
         LocalDateTime now = LocalDateTime.now();
-        return switch (homeSort) {
-            case RELEASE_NOW -> itemRepository.getReleaseTodayItemOrdered(userId, now);
-            case RELEASE_WISH -> itemRepository.getReleaseWishItemOrdered(userId, now);
-            case RELEASE_CONFIRM -> itemRepository.getJustConfirmReleaseItemOrdered(userId, now);
-            case REGISTER_TODAY -> itemRepository.getRegisterTodayItemOrdered(userId, now);
-            default -> itemRepository.getDueTodayItemOrdered(userId, now);
-        };
+        return itemRepository.getHomeSortList(userId, LocalDateTime.now(), category, homeSort);
     }
 
     @Transactional

--- a/src/main/java/com/ward/ward_server/api/item/service/ItemService.java
+++ b/src/main/java/com/ward/ward_server/api/item/service/ItemService.java
@@ -11,10 +11,13 @@ import com.ward.ward_server.api.item.repository.BrandRepository;
 import com.ward.ward_server.api.item.repository.ItemImageRepository;
 import com.ward.ward_server.api.item.repository.ItemRepository;
 import com.ward.ward_server.api.item.repository.ItemViewCountRepository;
+import com.ward.ward_server.global.Object.PageResponse;
 import com.ward.ward_server.global.Object.enums.HomeSort;
 import com.ward.ward_server.global.exception.ApiException;
 import com.ward.ward_server.global.util.ValidationUtils;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -23,6 +26,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import static com.ward.ward_server.global.Object.Constants.API_PAGE_SIZE;
 import static com.ward.ward_server.global.exception.ExceptionCode.*;
 import static com.ward.ward_server.global.response.error.ErrorMessage.NAME_MUST_BE_PROVIDED;
 import static com.ward.ward_server.global.response.error.ErrorMessage.REQUIRED_FIELDS_MUST_BE_PROVIDED;
@@ -88,8 +92,13 @@ public class ItemService {
 
     @Transactional(readOnly = true)
     public List<ItemSimpleResponse> getItem10List(Long userId, HomeSort homeSort, Category category) {
-        LocalDateTime now = LocalDateTime.now();
         return itemRepository.getHomeSortList(userId, LocalDateTime.now(), category, homeSort);
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponse<ItemSimpleResponse> getItemPage(Long userId, HomeSort homeSort, Category category, int page) {
+        Page<ItemSimpleResponse> itemPageInfo = itemRepository.getHomeSortPage(userId, LocalDateTime.now(), category, homeSort, PageRequest.of(page, API_PAGE_SIZE));
+        return new PageResponse<>(itemPageInfo.getContent(), itemPageInfo);
     }
 
     @Transactional

--- a/src/main/java/com/ward/ward_server/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/ward/ward_server/global/config/WebSecurityConfig.java
@@ -42,6 +42,7 @@ public class WebSecurityConfig {
                     // User endpoints
                     authorize
                             .requestMatchers("/items/details").hasAnyRole("USER", "ADMIN")
+                            .requestMatchers(HttpMethod.GET,"/items/home").hasAnyRole("USER", "ADMIN")
                             .requestMatchers(HttpMethod.GET, "/items").hasAnyRole("USER", "ADMIN");
 
                     // Public endpoints

--- a/src/test/java/com/ward/ward_server/api/item/repository/ItemRepositoryTest.java
+++ b/src/test/java/com/ward/ward_server/api/item/repository/ItemRepositoryTest.java
@@ -4,23 +4,29 @@ import com.ward.ward_server.api.item.dto.ItemSimpleResponse;
 import com.ward.ward_server.api.item.entity.Brand;
 import com.ward.ward_server.api.item.entity.Item;
 import com.ward.ward_server.api.item.entity.enums.Category;
+import com.ward.ward_server.api.releaseInfo.dto.ReleaseInfoSimpleResponse;
 import com.ward.ward_server.api.releaseInfo.entity.DrawPlatform;
 import com.ward.ward_server.api.releaseInfo.entity.ReleaseInfo;
 import com.ward.ward_server.api.releaseInfo.entity.enums.CurrencyUnit;
 import com.ward.ward_server.api.releaseInfo.entity.enums.DeliveryMethod;
 import com.ward.ward_server.api.releaseInfo.entity.enums.NotificationMethod;
 import com.ward.ward_server.api.releaseInfo.entity.enums.ReleaseMethod;
+import com.ward.ward_server.api.releaseInfo.repository.ReleaseInfoRepository;
 import com.ward.ward_server.api.user.entity.User;
 import com.ward.ward_server.api.wishItem.WishItem;
+import com.ward.ward_server.global.Object.enums.HomeSort;
 import com.ward.ward_server.global.config.QuerydslConfig;
 import jakarta.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
+import net.bytebuddy.asm.Advice;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -28,7 +34,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static com.ward.ward_server.global.Object.Constants.DATE_STRING_FORMAT;
+import static com.ward.ward_server.global.Object.Constants.*;
+import static com.ward.ward_server.global.Object.Constants.API_PAGE_SIZE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
@@ -42,197 +49,281 @@ class ItemRepositoryTest {
     ItemRepository itemRepository;
     List<Item> items = new ArrayList<>();
     User user;
+    DrawPlatform drawPlatform;
 
     @BeforeEach
     public void before() {
+        user = new User("이름", "이메일", "비밀번호", "닉네임", true, true, true);
+        em.persist(user);
+
         Brand brand = new Brand("로고이미지", "브랜드이름", "englishName");
         em.persist(brand);
+
+        drawPlatform = new DrawPlatform("테스트플랫폼", "testPlatform", "플랫폼이미지");
+        em.persist(drawPlatform);
+
+        //index 0~29는 FOOTWEAR 상품이다.
         for (int i = 1; i <= 30; i++) {
             Item item = new Item("상품코드", "상품이름" + i, "englishName", "메인이미지", brand, Category.FOOTWEAR, 10000);
             em.persist(item);
             items.add(item);
         }
-        user = new User("이름", "이메일", "비밀번호", "닉네임", true, true, true);
-        em.persist(user);
+        //index 30~59는 CLOTHING 상품이다.
+        for (int i = 31; i <= 60; i++) {
+            Item item = new Item("상품코드", "상품이름" + i, "englishName", "메인이미지", brand, Category.CLOTHING, 10000);
+            em.persist(item);
+            items.add(item);
+        }
     }
 
     @Test
-    public void 오늘_마감인_상품_조회() {
+    public void 오늘_마감인_발매정보_중_FOOTWEAR_상품을_가져온다() {
         //given
         LocalDateTime now = LocalDateTime.of(2024, 7, 3, 13, 30);
-        DrawPlatform drawPlatform = new DrawPlatform("테스트플랫폼", "testPlatform", "플랫폼이미지");
-        em.persist(drawPlatform);
         for (int itemId = 1; itemId <= 10; itemId++) {
-            // 마감일 = 오늘, 발매일 < 지금 < 마감일 < 발표일
+            // 마감일 = 오늘, 발매일 < 지금 < 마감일 < 발표일 (조건 만족)
             em.persist(new ReleaseInfo(items.get(itemId - 1), drawPlatform, "주소", now.minusDays(3).format(DATE_STRING_FORMAT), now.plusMinutes(itemId).format(DATE_STRING_FORMAT), now.plusDays(3).format(DATE_STRING_FORMAT), 30000, CurrencyUnit.KRW, NotificationMethod.EMAIL, ReleaseMethod.ENTRY, DeliveryMethod.AGENCY));
-            // 마감일 = 오늘, 발매일 < 지금 < 마감일 < 발표일, 정렬 확인용
+
+            // 마감일 = 오늘, 발매일 < 지금 < 마감일 < 발표일 (조건 만족), 정렬 확인용
             em.persist(new ReleaseInfo(items.get(itemId - 1 + 10), drawPlatform, "주소", now.minusDays(3).format(DATE_STRING_FORMAT), now.plusMinutes(itemId).format(DATE_STRING_FORMAT), now.plusDays(3).format(DATE_STRING_FORMAT), 30000, CurrencyUnit.KRW, NotificationMethod.EMAIL, ReleaseMethod.ENTRY, DeliveryMethod.AGENCY));
-            // 마감일 = 오늘, 발매일 < 마감일 < 지금 < 발표일
+
+            // 마감일 = 오늘, 발매일 < 마감일 < 지금 < 발표일 (조건 불만족)
             em.persist(new ReleaseInfo(items.get(itemId - 1 + 20), drawPlatform, "주소", now.minusDays(3).format(DATE_STRING_FORMAT), now.minusMinutes(itemId).format(DATE_STRING_FORMAT), now.plusDays(3).format(DATE_STRING_FORMAT), 30000, CurrencyUnit.KRW, NotificationMethod.EMAIL, ReleaseMethod.ENTRY, DeliveryMethod.AGENCY));
         }
         em.flush();
         em.clear();
 
         //when
-        List<ItemSimpleResponse> result = itemRepository.getDueTodayItemOrdered(user.getId(), now);
+        List<ItemSimpleResponse> result = itemRepository.getHomeSortList(user.getId(), now, Category.FOOTWEAR, HomeSort.DUE_TODAY);
 
         //then
-        log.debug("\n결과: {}", result.stream()
-                .map(ItemSimpleResponse::toString)
-                .collect(Collectors.joining("\n")));
-
         assertThat(result.size()).isEqualTo(10);
+        //1~30 중에서 6~10, 16~30은 제외한다. (= 1~5, 11~15는 포함한다)
         assertThat(result).extracting("itemKoreanName").doesNotContain(
                 IntStream.rangeClosed(1, 30)
                         .boxed()
                         .filter(e -> (6 <= e && e < 11) || 16 <= e)
                         .map(e -> "상품이름" + e)
                         .toArray());
+        //정렬 확인한다.
+        assertThat(result.get(0).itemKoreanName()).isEqualTo("상품이름1");
+        assertThat(result.get(1).itemKoreanName()).isEqualTo("상품이름11");
     }
 
     @Test
-    public void 현재_발매중인_상품_조회() {
+    public void 현재_발매중인_발매정보_중_FOOTWEAR_상품을_가져온다() {
         //given
         LocalDateTime now = LocalDateTime.of(2024, 7, 3, 13, 30);
-        DrawPlatform drawPlatform = new DrawPlatform("테스트플랫폼", "testPlatform", "플랫폼이미지");
-        em.persist(drawPlatform);
         for (int itemId = 1; itemId <= 5; itemId++) {
-            // 지금 < 발매일 < 마감일 < 발표일
-            em.persist(new ReleaseInfo(items.get(itemId - 1), drawPlatform, "주소" + itemId, now.plusDays(itemId).format(DATE_STRING_FORMAT), now.plusDays(itemId + 3).format(DATE_STRING_FORMAT), now.plusDays(itemId + 5).format(DATE_STRING_FORMAT), 30000, CurrencyUnit.KRW, NotificationMethod.EMAIL, ReleaseMethod.ENTRY, DeliveryMethod.AGENCY));
-            // 발매일 < 마감일 < 지금 < 발표일
+            // 지금 < 발매일 < 마감일 < 발표일 (조건 불만족)
+            em.persist(new ReleaseInfo(items.get(itemId - 1), drawPlatform, "주소", now.plusDays(itemId).format(DATE_STRING_FORMAT), now.plusDays(itemId + 3).format(DATE_STRING_FORMAT), now.plusDays(itemId + 5).format(DATE_STRING_FORMAT), 30000, CurrencyUnit.KRW, NotificationMethod.EMAIL, ReleaseMethod.ENTRY, DeliveryMethod.AGENCY));
+
+            // 발매일 < 마감일 < 지금 < 발표일 (조건 불만족)
             em.persist(new ReleaseInfo(items.get(itemId - 1 + 5), drawPlatform, "주소", now.minusDays(itemId + 3).format(DATE_STRING_FORMAT), now.minusDays(itemId).format(DATE_STRING_FORMAT), now.plusDays(itemId + 5).format(DATE_STRING_FORMAT), 30000, CurrencyUnit.KRW, NotificationMethod.EMAIL, ReleaseMethod.ENTRY, DeliveryMethod.AGENCY));
-            // 발매일 < 지금 < 마감일 < 발표일
+
+            // 발매일 < 지금 < 마감일 < 발표일 (조건 만족)
             em.persist(new ReleaseInfo(items.get(itemId - 1 + 10), drawPlatform, "주소", now.minusDays(itemId).format(DATE_STRING_FORMAT), now.plusMinutes(itemId).format(DATE_STRING_FORMAT), now.plusDays(itemId + 5).format(DATE_STRING_FORMAT), 30000, CurrencyUnit.KRW, NotificationMethod.EMAIL, ReleaseMethod.ENTRY, DeliveryMethod.AGENCY));
-            // 발매일 < 지금 < 마감일 < 발표일, 정렬 확인용
+
+            // 발매일 < 지금 < 마감일 < 발표일 (조건 만족), 정렬 확인용
             em.persist(new ReleaseInfo(items.get(itemId - 1 + 15), drawPlatform, "주소", now.minusDays(itemId).format(DATE_STRING_FORMAT), now.plusMinutes(itemId).format(DATE_STRING_FORMAT), now.plusDays(itemId + 5).format(DATE_STRING_FORMAT), 30000, CurrencyUnit.KRW, NotificationMethod.EMAIL, ReleaseMethod.ENTRY, DeliveryMethod.AGENCY));
         }
         em.flush();
         em.clear();
 
         //when
-        List<ItemSimpleResponse> result = itemRepository.getReleaseTodayItemOrdered(user.getId(), now);
+        List<ItemSimpleResponse> result = itemRepository.getHomeSortList(user.getId(), now, Category.FOOTWEAR, HomeSort.RELEASE_NOW);
 
         //then
-        log.debug("\n결과: {}", result.stream()
-                .map(ItemSimpleResponse::toString)
-                .collect(Collectors.joining("\n")));
-
         assertThat(result.size()).isEqualTo(10);
+        //1~20 중에서 11~20를 포함한다.
         assertThat(result).extracting("itemKoreanName").contains(
                 IntStream.rangeClosed(11, 20)
                         .boxed()
                         .map(e -> "상품이름" + e)
                         .toArray());
+        //정렬 확인한다.
+        assertThat(result.get(0).itemKoreanName()).isEqualTo("상품이름11");
+        assertThat(result.get(1).itemKoreanName()).isEqualTo("상품이름16");
     }
 
     @Test
-    public void 관심상품_중에_현재_발매중인_상품_조회() {
+    public void FOOTWEAR_관심상품_중에서_현재_발매중인_상품을_가져온다() {
         //given
         LocalDateTime now = LocalDateTime.of(2024, 7, 3, 13, 30);
-        DrawPlatform drawPlatform = new DrawPlatform("테스트플랫폼", "testPlatform", "플랫폼이미지");
-        em.persist(drawPlatform);
-
-        for (long itemId = 5; itemId <= 15; itemId++)
-            em.persist(new WishItem(user, itemRepository.findById(itemId).get()));
+        //index가 4~19인 상품이 관심상품이다.
+        for (int itemId = 5; itemId <= 20; itemId++) {
+            em.persist(new WishItem(user, items.get(itemId - 1)));
+        }
         for (int itemId = 1; itemId <= 5; itemId++) {
-            // 지금 < 발매일 < 마감일 < 발표일
-            em.persist(new ReleaseInfo(items.get(itemId - 1), drawPlatform, "주소" + itemId, now.plusDays(itemId).format(DATE_STRING_FORMAT), now.plusDays(itemId + 3).format(DATE_STRING_FORMAT), now.plusDays(itemId + 5).format(DATE_STRING_FORMAT), 30000, CurrencyUnit.KRW, NotificationMethod.EMAIL, ReleaseMethod.ENTRY, DeliveryMethod.AGENCY));
-            // 발매일 < 마감일 < 지금 < 발표일
+            // 지금 < 발매일 < 마감일 < 발표일 (조건 불만족)
+            em.persist(new ReleaseInfo(items.get(itemId - 1), drawPlatform, "주소", now.plusDays(itemId).format(DATE_STRING_FORMAT), now.plusDays(itemId + 3).format(DATE_STRING_FORMAT), now.plusDays(itemId + 5).format(DATE_STRING_FORMAT), 30000, CurrencyUnit.KRW, NotificationMethod.EMAIL, ReleaseMethod.ENTRY, DeliveryMethod.AGENCY));
+
+            // 발매일 < 마감일 < 지금 < 발표일 (조건 불만족)
             em.persist(new ReleaseInfo(items.get(itemId - 1 + 5), drawPlatform, "주소", now.minusDays(itemId + 3).format(DATE_STRING_FORMAT), now.minusDays(itemId).format(DATE_STRING_FORMAT), now.plusDays(itemId + 5).format(DATE_STRING_FORMAT), 30000, CurrencyUnit.KRW, NotificationMethod.EMAIL, ReleaseMethod.ENTRY, DeliveryMethod.AGENCY));
-            // 발매일 < 지금 < 마감일 < 발표일
-            em.persist(new ReleaseInfo(items.get(itemId - 1 + 10), drawPlatform, "주소", now.minusDays(itemId).format(DATE_STRING_FORMAT), now.plusMinutes(itemId).format(DATE_STRING_FORMAT), now.plusDays(itemId + 5).format(DATE_STRING_FORMAT), 30000, CurrencyUnit.KRW, NotificationMethod.EMAIL, ReleaseMethod.ENTRY, DeliveryMethod.AGENCY));
-            // 발매일 < 지금 < 마감일 < 발표일, 정렬 확인용
-            em.persist(new ReleaseInfo(items.get(itemId - 1 + 15), drawPlatform, "주소", now.minusDays(itemId).format(DATE_STRING_FORMAT), now.plusMinutes(itemId).format(DATE_STRING_FORMAT), now.plusDays(itemId + 5).format(DATE_STRING_FORMAT), 30000, CurrencyUnit.KRW, NotificationMethod.EMAIL, ReleaseMethod.ENTRY, DeliveryMethod.AGENCY));
+
+            // 발매일 < 지금 < 마감일 < 발표일 (조건 만족)
+            em.persist(new ReleaseInfo(items.get(itemId - 1 + 10), drawPlatform, "주소", now.minusDays(itemId * 2).format(DATE_STRING_FORMAT), now.plusMinutes(itemId * 2).format(DATE_STRING_FORMAT), now.plusDays(itemId + 5).format(DATE_STRING_FORMAT), 30000, CurrencyUnit.KRW, NotificationMethod.EMAIL, ReleaseMethod.ENTRY, DeliveryMethod.AGENCY));
+
+            // 발매일 < 지금 < 마감일 < 발표일 (조건 만족), 정렬 확인용
+            em.persist(new ReleaseInfo(items.get(itemId - 1 + 15), drawPlatform, "주소", now.minusDays(itemId * 2 + 1).format(DATE_STRING_FORMAT), now.plusMinutes(itemId * 2 + 1).format(DATE_STRING_FORMAT), now.plusDays(itemId + 5).format(DATE_STRING_FORMAT), 30000, CurrencyUnit.KRW, NotificationMethod.EMAIL, ReleaseMethod.ENTRY, DeliveryMethod.AGENCY));
         }
         em.flush();
         em.clear();
 
-
         //when
-        List<ItemSimpleResponse> result = itemRepository.getReleaseWishItemOrdered(user.getId(), now);
+        List<ItemSimpleResponse> result = itemRepository.getHomeSortList(user.getId(), now, Category.FOOTWEAR, HomeSort.RELEASE_WISH);
 
         //then
-        log.debug("\n결과: {}", result.stream()
-                .map(ItemSimpleResponse::toString)
-                .collect(Collectors.joining("\n")));
-
-        assertThat(result.size()).isEqualTo(5);
+        assertThat(result.size()).isEqualTo(10);
+        //1~20 중에서 11~20 상품을 포함한다.
         assertThat(result).extracting("itemKoreanName").contains(
-                IntStream.rangeClosed(11, 15)
+                IntStream.rangeClosed(11, 20)
                         .boxed()
                         .map(e -> "상품이름" + e)
                         .toArray());
+        //정렬 확인한다.
+        assertThat(result.get(0).itemKoreanName()).isEqualTo("상품이름11");
+        assertThat(result.get(1).itemKoreanName()).isEqualTo("상품이름16");
     }
 
+
     @Test
-    public void 발매날짜는_확정이지만_미발매인_상품_조회() {
+    public void 발매날짜가_확정됐지만_미발매인_FOOTWEAR_상품을_가져온다() {
         //given
         LocalDateTime now = LocalDateTime.of(2024, 7, 3, 13, 30);
-        DrawPlatform drawPlatform = new DrawPlatform("테스트플랫폼", "testPlatform", "플랫폼이미지");
-        em.persist(drawPlatform);
         for (int itemId = 1; itemId <= 10; itemId++) {
-            // 지금 < 발매일 < 마감일 < 발표일
-            em.persist(new ReleaseInfo(items.get(itemId - 1), drawPlatform, "주소" + itemId, now.plusDays(itemId).format(DATE_STRING_FORMAT), now.plusDays(itemId + 3).format(DATE_STRING_FORMAT), now.plusDays(itemId + 5).format(DATE_STRING_FORMAT), 30000, CurrencyUnit.KRW, NotificationMethod.EMAIL, ReleaseMethod.ENTRY, DeliveryMethod.AGENCY));
-            // 지금 < 발매일 < 마감일 < 발표일, 정렬 확인용
-            em.persist(new ReleaseInfo(items.get(itemId - 1 + 10), drawPlatform, "주소" + itemId, now.plusDays(itemId).format(DATE_STRING_FORMAT), now.plusDays(itemId + 3).format(DATE_STRING_FORMAT), now.plusDays(itemId + 5).format(DATE_STRING_FORMAT), 30000, CurrencyUnit.KRW, NotificationMethod.EMAIL, ReleaseMethod.ENTRY, DeliveryMethod.AGENCY));
-            // 발매일 < 지금 < 마감일 < 발표일
+            // 지금 < 발매일 < 마감일 < 발표일 (조건 만족)
+            em.persist(new ReleaseInfo(items.get(itemId - 1), drawPlatform, "주소", now.plusDays(itemId * 2).format(DATE_STRING_FORMAT), now.plusDays(itemId + 3).format(DATE_STRING_FORMAT), now.plusDays(itemId + 5).format(DATE_STRING_FORMAT), 30000, CurrencyUnit.KRW, NotificationMethod.EMAIL, ReleaseMethod.ENTRY, DeliveryMethod.AGENCY));
+
+            // 지금 < 발매일 < 마감일 < 발표일 (조건 만족), 정렬 확인용
+            em.persist(new ReleaseInfo(items.get(itemId - 1 + 10), drawPlatform, "주소" + itemId, now.plusDays(itemId * 2 + 1).format(DATE_STRING_FORMAT), now.plusDays(itemId + 3).format(DATE_STRING_FORMAT), now.plusDays(itemId + 5).format(DATE_STRING_FORMAT), 30000, CurrencyUnit.KRW, NotificationMethod.EMAIL, ReleaseMethod.ENTRY, DeliveryMethod.AGENCY));
+
+            // 발매일 < 지금 < 마감일 < 발표일 (조건 불만족)
             em.persist(new ReleaseInfo(items.get(itemId - 1 + 20), drawPlatform, "주소", now.minusDays(itemId).format(DATE_STRING_FORMAT), now.plusMinutes(itemId).format(DATE_STRING_FORMAT), now.plusDays(itemId + 5).format(DATE_STRING_FORMAT), 30000, CurrencyUnit.KRW, NotificationMethod.EMAIL, ReleaseMethod.ENTRY, DeliveryMethod.AGENCY));
         }
         em.flush();
         em.clear();
 
         //when
-        List<ItemSimpleResponse> result = itemRepository.getJustConfirmReleaseItemOrdered(user.getId(), now);
+        List<ItemSimpleResponse> result = itemRepository.getHomeSortList(user.getId(), now, Category.FOOTWEAR, HomeSort.RELEASE_CONFIRM);
 
         //then
-        log.debug("\n결과: {}", result.stream()
-                .map(ItemSimpleResponse::toString)
-                .collect(Collectors.joining("\n")));
-
-        assertThat(result.size()).isEqualTo(10);
+        assertThat(result.size()).isEqualTo(HOME_PAGE_SIZE);
+        //1~30 중에서 6~10, 16~30은 제외한다. (= 1~5, 11~15는 포함한다)
         assertThat(result).extracting("itemKoreanName").doesNotContain(
                 IntStream.rangeClosed(1, 30)
                         .boxed()
                         .filter(e -> (6 <= e && e < 11) || 16 <= e)
                         .map(e -> "상품이름" + e)
                         .toArray());
+        //정렬 확인한다.
+        assertThat(result.get(0).itemKoreanName()).isEqualTo("상품이름1");
+        assertThat(result.get(1).itemKoreanName()).isEqualTo("상품이름11");
     }
 
     @Test
-    public void 오늘_등록하고_미발매인_상품_조회() {
+    public void 오늘_등록한_FOOTWEAR_상품을_가져온다() {
+        LocalDateTime now = LocalDateTime.now();
         //given
-        Brand brand = new Brand("로고", "브랜드", "brand");
-        em.persist(brand);
         for (int itemId = 1; itemId <= 10; itemId++) {
-            em.persist(Item.builder()
-                    .koreanName("상품이름" + itemId)
-                    .code("상품코드" + itemId)
-                    .brand(brand)
-                    .category(Category.FOOTWEAR).build());
-            //정렬 확인용
-            em.persist(Item.builder()
-                    .koreanName("상품이름" + (itemId + 10))
-                    .code("상품코드" + (itemId + 10))
-                    .brand(brand)
-                    .category(Category.FOOTWEAR).build());
+            // 지금 < 발매일 < 마감일 < 발표일 (조건 만족)
+            em.persist(new ReleaseInfo(items.get(itemId - 1), drawPlatform, "주소", now.plusDays(itemId).format(DATE_STRING_FORMAT), now.plusDays(itemId + 3).format(DATE_STRING_FORMAT), now.plusDays(itemId + 5).format(DATE_STRING_FORMAT), 30000, CurrencyUnit.KRW, NotificationMethod.EMAIL, ReleaseMethod.ENTRY, DeliveryMethod.AGENCY));
+
+            // 지금 < 발매일 < 마감일 < 발표일 (조건 만족), 정렬 확인용
+            em.persist(new ReleaseInfo(items.get(itemId - 1 + 10), drawPlatform, "주소", now.plusDays(itemId).format(DATE_STRING_FORMAT), now.plusDays(itemId + 3).format(DATE_STRING_FORMAT), now.plusDays(itemId + 5).format(DATE_STRING_FORMAT), 30000, CurrencyUnit.KRW, NotificationMethod.EMAIL, ReleaseMethod.ENTRY, DeliveryMethod.AGENCY));
         }
         em.flush();
         em.clear();
 
         //when
-        List<ItemSimpleResponse> result = itemRepository.getRegisterTodayItemOrdered(user.getId(), LocalDateTime.now());
+        List<ItemSimpleResponse> result = itemRepository.getHomeSortList(user.getId(), now, Category.FOOTWEAR, HomeSort.REGISTER_TODAY);
 
         //then
-        log.debug("\n결과: {}", result.stream()
-                .map(ItemSimpleResponse::toString)
-                .collect(Collectors.joining("\n")));
-
-        assertThat(result.size()).isEqualTo(10);
+        assertThat(result.size()).isEqualTo(HOME_PAGE_SIZE);
+        //1~20 중에서 6~10, 16~20은 제외한다. (= 1~5, 11~15는 포함한다)
         assertThat(result).extracting("itemKoreanName").doesNotContain(
                 IntStream.rangeClosed(1, 20)
                         .boxed()
                         .filter(e -> (6 <= e && e < 11) || 16 <= e)
                         .map(e -> "상품이름" + e)
                         .toArray());
+        //정렬 확인한다.
+        assertThat(result.get(0).itemKoreanName()).isEqualTo("상품이름1");
+        assertThat(result.get(1).itemKoreanName()).isEqualTo("상품이름11");
+    }
+
+    @Test
+    public void ALL_카테고리는_FOOTWEAR과_CLOTHING인_상품을_다_가져온다() {
+        //given
+        LocalDateTime now = LocalDateTime.now();
+        for (int itemId = 1; itemId <= 10; itemId++) {
+            // 지금 < 발매일 < 마감일 < 발표일 (조건 만족), FOOTWEAR 상품
+            em.persist(new ReleaseInfo(items.get(itemId - 1), drawPlatform, "주소", now.plusDays(itemId).format(DATE_STRING_FORMAT), now.plusDays(itemId + 3).format(DATE_STRING_FORMAT), now.plusDays(itemId + 5).format(DATE_STRING_FORMAT), 30000, CurrencyUnit.KRW, NotificationMethod.EMAIL, ReleaseMethod.ENTRY, DeliveryMethod.AGENCY));
+
+            // 지금 < 발매일 < 마감일 < 발표일 (조건 만족), CLOTHING 상품
+            em.persist(new ReleaseInfo(items.get(itemId - 1 + 30), drawPlatform, "주소", now.plusDays(itemId).format(DATE_STRING_FORMAT), now.plusDays(itemId + 3).format(DATE_STRING_FORMAT), now.plusDays(itemId + 5).format(DATE_STRING_FORMAT), 30000, CurrencyUnit.KRW, NotificationMethod.EMAIL, ReleaseMethod.ENTRY, DeliveryMethod.AGENCY));
+        }
+        em.flush();
+        em.clear();
+
+        //when
+        List<ItemSimpleResponse> result = itemRepository.getHomeSortList(user.getId(), now, Category.ALL, HomeSort.REGISTER_TODAY);
+
+        //then
+        assertThat(result.size()).isEqualTo(HOME_PAGE_SIZE);
+        //1~40 중에서 6~30, 36~40는 제외한다. (= 1~5, 31~35는 포함한다)
+        assertThat(result).extracting("itemKoreanName").doesNotContain(
+                IntStream.rangeClosed(1, 40)
+                        .boxed()
+                        .filter(e -> (6 <= e && e < 31) || 35 < e)
+                        .map(e -> "상품이름" + e)
+                        .toArray());
+        //정렬 확인한다.
+        assertThat(result.get(0).itemKoreanName()).isEqualTo("상품이름1");
+        assertThat(result.get(1).itemKoreanName()).isEqualTo("상품이름31");
+    }
+
+    @Test
+    public void 총_상품의_개수가_total일때_마지막_페이지를_가져온다() {
+        //given
+        LocalDateTime now = LocalDateTime.now();
+        int total = 48;
+        for (int itemId = 1; itemId <= total / 2; itemId++) {
+            // 지금 < 발매일 < 마감일 < 발표일 (조건 만족), FOOTWEAR 상품
+            em.persist(new ReleaseInfo(items.get(itemId - 1), drawPlatform, "주소", now.plusDays(itemId).format(DATE_STRING_FORMAT), now.plusDays(itemId + 3).format(DATE_STRING_FORMAT), now.plusDays(itemId + 5).format(DATE_STRING_FORMAT), 30000, CurrencyUnit.KRW, NotificationMethod.EMAIL, ReleaseMethod.ENTRY, DeliveryMethod.AGENCY));
+
+            // 지금 < 발매일 < 마감일 < 발표일 (조건 만족), CLOTHING 상품
+            em.persist(new ReleaseInfo(items.get(itemId - 1 + 30), drawPlatform, "주소", now.plusDays(itemId).format(DATE_STRING_FORMAT), now.plusDays(itemId + 3).format(DATE_STRING_FORMAT), now.plusDays(itemId + 5).format(DATE_STRING_FORMAT), 30000, CurrencyUnit.KRW, NotificationMethod.EMAIL, ReleaseMethod.ENTRY, DeliveryMethod.AGENCY));
+        }
+        em.flush();
+        em.clear();
+
+        //when
+        int page = total % API_PAGE_SIZE == 0 ? (total / API_PAGE_SIZE) : (total / API_PAGE_SIZE + 1);
+        Page<ItemSimpleResponse> result = itemRepository.getHomeSortPage(user.getId(), now, Category.ALL, HomeSort.REGISTER_TODAY, PageRequest.of(page - 1, API_PAGE_SIZE));
+
+        //then
+        assertThat(result.getContent().size()).isEqualTo(total % API_PAGE_SIZE);
+        assertThat(result.getTotalElements()).isEqualTo(total);
+        assertThat(result.getNumber()).isEqualTo(page - 1);
+        assertThat(result.getTotalPages()).isEqualTo(page);
+        //마지막 값을 확인한다.
+        assertThat(result.getContent().get(total % API_PAGE_SIZE == 0 ? API_PAGE_SIZE - 1 : (total % API_PAGE_SIZE) - 1).itemKoreanName()).isEqualTo("상품이름" + (total / 2 + 30));
+    }
+
+    @Test
+    public void 중복된_상품을_제거한다() {
+        //given
+        LocalDateTime now = LocalDateTime.now();
+        int itemIndex = 10;
+        em.persist(new ReleaseInfo(items.get(itemIndex), drawPlatform, "주소1", now.plusDays(3).format(DATE_STRING_FORMAT), now.plusDays(5).format(DATE_STRING_FORMAT), now.plusDays(7).format(DATE_STRING_FORMAT), 30000, CurrencyUnit.KRW, NotificationMethod.EMAIL, ReleaseMethod.ENTRY, DeliveryMethod.AGENCY));
+        em.persist(new ReleaseInfo(items.get(itemIndex), drawPlatform, "주소2", now.plusDays(2).format(DATE_STRING_FORMAT), now.plusDays(4).format(DATE_STRING_FORMAT), now.plusDays(6).format(DATE_STRING_FORMAT), 30000, CurrencyUnit.KRW, NotificationMethod.EMAIL, ReleaseMethod.ENTRY, DeliveryMethod.AGENCY));
+
+        //when
+        List<ItemSimpleResponse> result = itemRepository.getHomeSortList(user.getId(), now, Category.FOOTWEAR, HomeSort.REGISTER_TODAY);
+
+        //then
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(result.get(0).itemKoreanName()).isEqualTo("상품이름" + (itemIndex + 1));
     }
 }


### PR DESCRIPTION
## 요약
카테고리별, 정렬별 상품 목록/페이지 조회 API 구현

## 작업 내용
f409942e1d9b300f028d08047a6252625dcae008
기존 홈화면 목록 10개 조회 API 리팩토링
1. 동적쿼리 적용
2. 카테고리 입력받도록 수정
3. ItemSimpleResponse 필드명 수정 wished -> isWished

1c60a8a0eee305d995a7edc053b40ba45286ab9a
1. 페이지 조회 API
2. 중복된 상품이 뜨지 않도록 로직 수정

8fb98dad60973a0b175c2fc7a49011f53504385b
테스트 코드 작성 및 쿼리문 비교 시간 설정

## 참고 사항

## 관련 이슈

- Close #69
