### PR TITLE
refactor: @RequestParam 어노테이션에 괄호 추가

### DIFF
--- a/src/main/java/com/ward/ward_server/api/releaseInfo/controller/ReleaseInfoController.java
+++ b/src/main/java/com/ward/ward_server/api/releaseInfo/controller/ReleaseInfoController.java
@@ -51,15 +51,15 @@ public class ReleaseInfoController {
 
     @GetMapping("/home")
     public ApiResponse<List<ReleaseInfoSimpleResponse>> getReleaseInfo10List(@AuthenticationPrincipal CustomUserDetails principal,
-                                                                             @RequestParam HomeSort sort,
-                                                                             @RequestParam Category category) {
+                                                                             @RequestParam("sort") HomeSort sort,
+                                                                             @RequestParam("category") Category category) {
         return ApiResponse.ok(RELEASE_INFO_LIST_LOAD_SUCCESS, releaseInfoService.getReleaseInfo10List(principal.getUserId(), sort, category));
     }
 
     @GetMapping
     public ApiResponse<PageResponse<ReleaseInfoSimpleResponse>> getReleaseInfoPage(@AuthenticationPrincipal CustomUserDetails principal,
-                                                                                   @RequestParam HomeSort sort,
-                                                                                   @RequestParam Category category,
+                                                                                   @RequestParam("sort") HomeSort sort,
+                                                                                   @RequestParam("category") Category category,
                                                                                    @Positive @RequestParam(value = "page") int page) {
         return ApiResponse.ok(RELEASE_INFO_LIST_LOAD_SUCCESS, releaseInfoService.getReleaseInfoPage(principal.getUserId(), sort, category, page - 1));
     }


### PR DESCRIPTION
## 요약
ReleaseInfoController 에 @RequestParam 어노테이션 뒤에 괄호 추가

## 작업 내용
- @RequestParam 어노테이션에 괄호를 추가하여 코드의 가독성과 일관성을 높였습니다.
- 각 메서드의 파라미터 선언을 명확히 하기 위해 적용했습니다.
- 특정 버전이나 설정에서 괄호를 붙이지 않으면 동작하지 않는 경우가 있다고 합니다. 붙이는걸로 통일하면 좋을 듯 합니다.

## 참고 사항

## 관련 이슈

- Close #이슈번호
