### PR TITLE
User권한으로 Admin 권한에 접근 시 에러 구체화

### DIFF
--- a/src/main/java/com/ward/ward_server/api/user/auth/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/ward/ward_server/api/user/auth/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,26 @@
+package com.ward.ward_server.api.user.auth.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ward.ward_server.global.exception.ExceptionCode;
+import com.ward.ward_server.global.response.ApiResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+
+        ApiResponse<?> apiResponse = ApiResponse.failure(ExceptionCode.ACCESS_DENIED, "접근 권한이 부족합니다.");
+        response.getWriter().write(new ObjectMapper().writeValueAsString(apiResponse));
+    }
+}

--- a/src/main/java/com/ward/ward_server/api/user/auth/security/UnauthorizedHandler.java
+++ b/src/main/java/com/ward/ward_server/api/user/auth/security/UnauthorizedHandler.java
@@ -12,9 +12,9 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
-// Security에서 인증되지 않은 사용자의 접근 시 발생하는 예외를 처리하는 클래스
 @Component
 public class UnauthorizedHandler implements AuthenticationEntryPoint {
+
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
         response.setContentType("application/json;charset=UTF-8");
@@ -40,5 +40,3 @@ public class UnauthorizedHandler implements AuthenticationEntryPoint {
         return ExceptionCode.INVALID_USERNAME_OR_PASSWORD;
     }
 }
-
-

--- a/src/main/java/com/ward/ward_server/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/ward/ward_server/global/config/WebSecurityConfig.java
@@ -1,5 +1,6 @@
 package com.ward.ward_server.global.config;
 
+import com.ward.ward_server.api.user.auth.security.CustomAccessDeniedHandler;
 import com.ward.ward_server.api.user.auth.security.CustomUserDetailService;
 import com.ward.ward_server.api.user.auth.security.JwtAuthenticationFilter;
 import com.ward.ward_server.api.user.auth.security.UnauthorizedHandler;
@@ -30,6 +31,7 @@ public class WebSecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final CustomUserDetailService customUserDetailService;
     private final UnauthorizedHandler unauthorizedHandler;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
 
     @Bean
     public SecurityFilterChain applicationSecurity(HttpSecurity http) throws Exception {
@@ -62,7 +64,10 @@ public class WebSecurityConfig {
 
                     authorize.anyRequest().authenticated();
                 })
-                .exceptionHandling(exception -> exception.authenticationEntryPoint(unauthorizedHandler))
+                .exceptionHandling(exception -> {
+                    exception.authenticationEntryPoint(unauthorizedHandler);
+                    exception.accessDeniedHandler(accessDeniedHandler);
+                })
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()));
@@ -103,4 +108,3 @@ public class WebSecurityConfig {
         return authenticationManagerBuilder.build();
     }
 }
-

--- a/src/main/java/com/ward/ward_server/global/exception/ExceptionCode.java
+++ b/src/main/java/com/ward/ward_server/global/exception/ExceptionCode.java
@@ -13,6 +13,7 @@ public enum ExceptionCode {
     INVALID_TOKEN(5003, "유효하지 않은 토큰입니다."),
     MISSING_AUTH_HEADER(5004, "Authorization 헤더가 누락되었습니다."),
     MISSING_REFRESH_TOKEN(5005, "리프레시 토큰이 누락되었습니다."),
+    ACCESS_DENIED(5006, "접근 권한이 부족합니다."),
 
     //유저 회원가입 및 로그인
     NON_EXISTENT_EMAIL(5201, "존재하지 않는 이메일입니다"),


### PR DESCRIPTION
## 요약
admin 접근 권한이 필요한 경로에 User 권한으로 접근 시 에러 메시지 "접근 권한이 부족합니다."

## 작업 내용
feat: 접근 권한 부족에 대한 자세한 오류 메시지를 위한 CustomAccessDeniedHandler 추가

- AccessDeniedException을 처리하고 자세한 오류 메시지를 반환하기 위한 CustomAccessDeniedHandler 구현
- WebSecurityConfig에 CustomAccessDeniedHandler 추가
- 특정 접근 권한 부족 오류 처리를 위한 ExceptionCode에 ACCESS_DENIED 추가

## 참고 사항

## 관련 이슈

- Close #이슈번호
