### PR TITLE
feat: 발매 정보 검색 API 구현

### DIFF
--- a/src/main/java/com/ward/ward_server/api/releaseInfo/repository/ReleaseInfoRepository.java
+++ b/src/main/java/com/ward/ward_server/api/releaseInfo/repository/ReleaseInfoRepository.java
@@ -11,8 +11,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Set;
 
 public interface ReleaseInfoRepository extends JpaRepository<ReleaseInfo, Long>, ReleaseInfoQueryRepository {
 
@@ -24,4 +22,17 @@ public interface ReleaseInfoRepository extends JpaRepository<ReleaseInfo, Long>,
 
     @Query("SELECT COUNT(r) FROM ReleaseInfo r WHERE r.item.id = :itemId")
     int countByItemId(@Param("itemId") Long itemId);
+
+    @Query("SELECT ri FROM ReleaseInfo ri " +
+            "JOIN ri.item i " +
+            "JOIN ri.drawPlatform dp " +
+            "JOIN i.brand b " +
+            "WHERE LOWER(i.koreanName) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "OR LOWER(i.englishName) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "OR LOWER(i.code) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "OR LOWER(b.koreanName) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "OR LOWER(b.englishName) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "OR LOWER(dp.koreanName) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "OR LOWER(dp.englishName) LIKE LOWER(CONCAT('%', :keyword, '%'))")
+    Page<ReleaseInfo> searchReleaseInfos(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/com/ward/ward_server/api/search/controller/SearchController.java
+++ b/src/main/java/com/ward/ward_server/api/search/controller/SearchController.java
@@ -1,6 +1,7 @@
 package com.ward.ward_server.api.search.controller;
 
 import com.ward.ward_server.api.search.dto.SearchItemsResponse;
+import com.ward.ward_server.api.search.dto.SearchReleaseInfoResponse;
 import com.ward.ward_server.api.search.service.SearchService;
 import com.ward.ward_server.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,14 @@ public class SearchController {
                                                         @RequestParam("page") int page,
                                                         @RequestParam("size") int size) {
         SearchItemsResponse searchResults = searchService.searchItems(keyword, page, size);
+        return ApiResponse.ok(searchResults);
+    }
+
+    @GetMapping("/release-infos")
+    public ApiResponse<SearchReleaseInfoResponse> searchReleaseInfos(@RequestParam("keyword") String keyword,
+                                                                     @RequestParam("page") int page,
+                                                                     @RequestParam("size") int size) {
+        SearchReleaseInfoResponse searchResults = searchService.searchReleaseInfos(keyword, page, size);
         return ApiResponse.ok(searchResults);
     }
 }

--- a/src/main/java/com/ward/ward_server/api/search/dto/SearchReleaseInfoResponse.java
+++ b/src/main/java/com/ward/ward_server/api/search/dto/SearchReleaseInfoResponse.java
@@ -1,0 +1,30 @@
+package com.ward.ward_server.api.search.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SearchReleaseInfoResponse {
+    private long totalCount;
+    private int totalPages;
+    private int currentPage;
+    private List<ReleaseInfoResult> results;
+
+    @Getter
+    @AllArgsConstructor
+    public static class ReleaseInfoResult {
+        private Long id;
+        private String mainImage;
+        private String platformEnglishName;
+        private String koreanName;
+        private String releaseDueDate;
+        private String releaseMethod;
+    }
+}

--- a/src/main/java/com/ward/ward_server/api/search/service/SearchService.java
+++ b/src/main/java/com/ward/ward_server/api/search/service/SearchService.java
@@ -2,8 +2,10 @@ package com.ward.ward_server.api.search.service;
 
 import com.ward.ward_server.api.item.entity.Item;
 import com.ward.ward_server.api.item.repository.ItemRepository;
+import com.ward.ward_server.api.releaseInfo.entity.ReleaseInfo;
 import com.ward.ward_server.api.releaseInfo.repository.ReleaseInfoRepository;
 import com.ward.ward_server.api.search.dto.SearchItemsResponse;
+import com.ward.ward_server.api.search.dto.SearchReleaseInfoResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -21,7 +23,6 @@ public class SearchService {
     private final ItemRepository itemRepository;
     private final ReleaseInfoRepository releaseInfoRepository;
 
-    @Transactional
     public SearchItemsResponse searchItems(String keyword, int page, int size) {
         Page<Item> items = itemRepository.searchItems(keyword, PageRequest.of(page, size));
 
@@ -42,6 +43,28 @@ public class SearchService {
                 items.getTotalElements(),
                 items.getTotalPages(),
                 items.getNumber(),
+                results
+        );
+    }
+
+    public SearchReleaseInfoResponse searchReleaseInfos(String keyword, int page, int size) {
+        Page<ReleaseInfo> releaseInfos = releaseInfoRepository.searchReleaseInfos(keyword, PageRequest.of(page, size));
+
+        List<SearchReleaseInfoResponse.ReleaseInfoResult> results = releaseInfos.getContent().stream().map(releaseInfo ->
+                new SearchReleaseInfoResponse.ReleaseInfoResult(
+                        releaseInfo.getId(),
+                        releaseInfo.getItem().getMainImage(),
+                        releaseInfo.getDrawPlatform().getEnglishName(),
+                        releaseInfo.getItem().getKoreanName(),
+                        releaseInfo.getDueFormatDate(),
+                        releaseInfo.getReleaseMethod().getDesc()
+                )
+        ).collect(Collectors.toList());
+
+        return new SearchReleaseInfoResponse(
+                releaseInfos.getTotalElements(),
+                releaseInfos.getTotalPages(),
+                releaseInfos.getNumber(),
                 results
         );
     }


### PR DESCRIPTION
## 요약
발매 정보 검색 API 구현

## 작업 내용
- 발매 정보 검색을 위한 엔드포인트 추가
- 검색 조건으로 브랜드 이름(한글/영문), 상품 이름(한글/영문), 상품 코드, 발매 플랫폼 이름(한글/영문)을 사용
- 페이징 기능 추가 (페이지 번호 및 페이지 크기)
- 검색 결과로 총 발매 정보 개수, 총 페이지 수, 현재 페이지, 발매 정보 리스트 반환
- 발매 정보 리스트는 상품 메인 이미지, 발매 플랫폼 영어 이름, 상품 한글 이름, 발매 마감 시각, 발매 방법(선착순/응모)을 포함

## 참고 사항
더미데이터에 선착순은 dueDate가 안 들어가 있는 부분 고쳐야 테스트 가능합니다.

## 관련 이슈

- Close #82 
