### PR TITLE
통합 검색 API 구현

### DIFF
--- a/src/main/java/com/ward/ward_server/api/item/entity/Item.java
+++ b/src/main/java/com/ward/ward_server/api/item/entity/Item.java
@@ -1,9 +1,12 @@
 package com.ward.ward_server.api.item.entity;
 
 import com.ward.ward_server.api.item.entity.enums.Category;
+import com.ward.ward_server.api.releaseInfo.entity.ReleaseInfo;
 import com.ward.ward_server.global.Object.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -35,6 +38,9 @@ public class Item extends BaseTimeEntity {
     private Category category;
 
     private Integer price;
+
+    @OneToMany(mappedBy = "item", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<ReleaseInfo> releaseInfos;
 
     @Builder
     public Item(String code, String koreanName, String englishName, String mainImage, Brand brand, Category category, Integer price) {

--- a/src/main/java/com/ward/ward_server/api/item/entity/Item.java
+++ b/src/main/java/com/ward/ward_server/api/item/entity/Item.java
@@ -1,12 +1,9 @@
 package com.ward.ward_server.api.item.entity;
 
 import com.ward.ward_server.api.item.entity.enums.Category;
-import com.ward.ward_server.api.releaseInfo.entity.ReleaseInfo;
 import com.ward.ward_server.global.Object.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
-
-import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -38,9 +35,6 @@ public class Item extends BaseTimeEntity {
     private Category category;
 
     private Integer price;
-
-    @OneToMany(mappedBy = "item", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    private List<ReleaseInfo> releaseInfos;
 
     @Builder
     public Item(String code, String koreanName, String englishName, String mainImage, Brand brand, Category category, Integer price) {

--- a/src/main/java/com/ward/ward_server/api/item/repository/BrandRepository.java
+++ b/src/main/java/com/ward/ward_server/api/item/repository/BrandRepository.java
@@ -3,13 +3,10 @@ package com.ward.ward_server.api.item.repository;
 import com.ward.ward_server.api.item.entity.Brand;
 import com.ward.ward_server.api.item.repository.query.BrandQueryRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface BrandRepository extends JpaRepository<Brand, Long>, BrandQueryRepository {
 
@@ -20,4 +17,11 @@ public interface BrandRepository extends JpaRepository<Brand, Long>, BrandQueryR
             "WHERE (:koreanName IS NULL OR b.koreanName = :koreanName) " +
             "AND (:englishName IS NULL OR b.englishName = :englishName)")
     boolean existsByKoreanNameOrEnglishName(@Param("koreanName") String koreanName, @Param("englishName") String englishName);
+
+    @Query("SELECT b " +
+            "FROM Brand b " +
+            "WHERE LOWER(b.koreanName) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "OR LOWER(b.englishName) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "ORDER BY b.koreanName ASC")
+    List<Brand> searchBrands(@Param("keyword") String keyword);
 }

--- a/src/main/java/com/ward/ward_server/api/search/controller/SearchController.java
+++ b/src/main/java/com/ward/ward_server/api/search/controller/SearchController.java
@@ -1,5 +1,6 @@
 package com.ward.ward_server.api.search.controller;
 
+import com.ward.ward_server.api.search.dto.IntegratedSearchResponse;
 import com.ward.ward_server.api.search.dto.SearchItemsResponse;
 import com.ward.ward_server.api.search.dto.SearchReleaseInfoResponse;
 import com.ward.ward_server.api.search.service.SearchService;
@@ -31,5 +32,13 @@ public class SearchController {
                                                                      @RequestParam("size") int size) {
         SearchReleaseInfoResponse searchResults = searchService.searchReleaseInfos(keyword, page, size);
         return ApiResponse.ok(searchResults);
+    }
+
+    @GetMapping("/integrated")
+    public ApiResponse<IntegratedSearchResponse> integratedSearch(@RequestParam("keyword") String keyword,
+                                                                  @RequestParam("page") int page,
+                                                                  @RequestParam("size") int size) {
+        IntegratedSearchResponse response = searchService.integratedSearch(keyword, page, size);
+        return ApiResponse.ok(response);
     }
 }

--- a/src/main/java/com/ward/ward_server/api/search/dto/IntegratedSearchResponse.java
+++ b/src/main/java/com/ward/ward_server/api/search/dto/IntegratedSearchResponse.java
@@ -1,0 +1,63 @@
+package com.ward.ward_server.api.search.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class IntegratedSearchResponse {
+    private List<BrandResult> brands;
+    private ItemSearchResult items;
+    private ReleaseInfoSearchResult releaseInfos;
+
+    @Getter
+    @AllArgsConstructor
+    public static class BrandResult {
+        private Long id;
+        private String logoImage;
+        private String koreanName;
+        private String englishName;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class ItemResult {
+        private Long id;
+        private String mainImage;
+        private String brandName;
+        private String koreanName;
+        private int releaseCount;
+        private long viewCount;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class ItemSearchResult {
+        private long totalCount;
+        private List<ItemResult> results;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class ReleaseInfoResult {
+        private Long id;
+        private String mainImage;
+        private String platformName;
+        private String koreanName;
+        private String releaseEndDate;
+        private String releaseMethod;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class ReleaseInfoSearchResult {
+        private long totalCount;
+        private List<ReleaseInfoResult> results;
+    }
+}

--- a/src/main/java/com/ward/ward_server/api/search/service/SearchService.java
+++ b/src/main/java/com/ward/ward_server/api/search/service/SearchService.java
@@ -1,9 +1,12 @@
 package com.ward.ward_server.api.search.service;
 
+import com.ward.ward_server.api.item.entity.Brand;
 import com.ward.ward_server.api.item.entity.Item;
+import com.ward.ward_server.api.item.repository.BrandRepository;
 import com.ward.ward_server.api.item.repository.ItemRepository;
 import com.ward.ward_server.api.releaseInfo.entity.ReleaseInfo;
 import com.ward.ward_server.api.releaseInfo.repository.ReleaseInfoRepository;
+import com.ward.ward_server.api.search.dto.IntegratedSearchResponse;
 import com.ward.ward_server.api.search.dto.SearchItemsResponse;
 import com.ward.ward_server.api.search.dto.SearchReleaseInfoResponse;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +23,7 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class SearchService {
 
+    private final BrandRepository brandRepository;
     private final ItemRepository itemRepository;
     private final ReleaseInfoRepository releaseInfoRepository;
 
@@ -67,5 +71,51 @@ public class SearchService {
                 releaseInfos.getNumber(),
                 results
         );
+    }
+
+    public IntegratedSearchResponse integratedSearch(String keyword, int page, int size) {
+        // Brand search
+        List<Brand> brands = brandRepository.searchBrands(keyword);
+        List<IntegratedSearchResponse.BrandResult> brandResults = brands.stream()
+                .map(brand -> new IntegratedSearchResponse.BrandResult(
+                        brand.getId(),
+                        brand.getLogoImage(),
+                        brand.getKoreanName(),
+                        brand.getEnglishName()))
+                .collect(Collectors.toList());
+
+        // Item search
+        Page<Item> items = itemRepository.searchItems(keyword, PageRequest.of(page, size));
+        List<IntegratedSearchResponse.ItemResult> itemResults = items.getContent().stream()
+                .map(item -> new IntegratedSearchResponse.ItemResult(
+                        item.getId(),
+                        item.getMainImage(),
+                        item.getBrand().getKoreanName(),
+                        item.getKoreanName(),
+                        item.getReleaseInfos().size(),
+                        item.getViewCount()))
+                .collect(Collectors.toList());
+        IntegratedSearchResponse.ItemSearchResult itemSearchResult = new IntegratedSearchResponse.ItemSearchResult(
+                items.getTotalElements(),
+                itemResults
+        );
+
+        // Release info search
+        Page<ReleaseInfo> releaseInfos = releaseInfoRepository.searchReleaseInfos(keyword, PageRequest.of(page, size));
+        List<IntegratedSearchResponse.ReleaseInfoResult> releaseInfoResults = releaseInfos.getContent().stream()
+                .map(releaseInfo -> new IntegratedSearchResponse.ReleaseInfoResult(
+                        releaseInfo.getId(),
+                        releaseInfo.getItem().getMainImage(),
+                        releaseInfo.getDrawPlatform().getEnglishName(),
+                        releaseInfo.getItem().getKoreanName(),
+                        releaseInfo.getDueFormatDate(),
+                        releaseInfo.getReleaseMethod().getDesc()))
+                .collect(Collectors.toList());
+        IntegratedSearchResponse.ReleaseInfoSearchResult releaseInfoSearchResult = new IntegratedSearchResponse.ReleaseInfoSearchResult(
+                releaseInfos.getTotalElements(),
+                releaseInfoResults
+        );
+
+        return new IntegratedSearchResponse(brandResults, itemSearchResult, releaseInfoSearchResult);
     }
 }

--- a/src/main/java/com/ward/ward_server/api/search/service/SearchService.java
+++ b/src/main/java/com/ward/ward_server/api/search/service/SearchService.java
@@ -87,13 +87,16 @@ public class SearchService {
         // Item search
         Page<Item> items = itemRepository.searchItems(keyword, PageRequest.of(page, size));
         List<IntegratedSearchResponse.ItemResult> itemResults = items.getContent().stream()
-                .map(item -> new IntegratedSearchResponse.ItemResult(
-                        item.getId(),
-                        item.getMainImage(),
-                        item.getBrand().getKoreanName(),
-                        item.getKoreanName(),
-                        item.getReleaseInfos().size(),
-                        item.getViewCount()))
+                .map(item -> {
+                    int releaseCount = releaseInfoRepository.countByItemId(item.getId());
+                    return new IntegratedSearchResponse.ItemResult(
+                            item.getId(),
+                            item.getMainImage(),
+                            item.getBrand().getKoreanName(),
+                            item.getKoreanName(),
+                            releaseCount,
+                            item.getViewCount());
+                })
                 .collect(Collectors.toList());
         IntegratedSearchResponse.ItemSearchResult itemSearchResult = new IntegratedSearchResponse.ItemSearchResult(
                 items.getTotalElements(),


### PR DESCRIPTION
## 요약
통합 검색 API 구현

## 작업 내용
2eee0c04e867695ad02a1d8d76b7761bc701a5ac
- 통합 검색을 위한 엔드포인트 추가
- 검색 조건으로 브랜드 이름(한글/영문), 상품 이름(한글/영문), 상품 코드, 발매 플랫폼 이름(한글/영문)을 사용
- 페이징 기능 추가 (페이지 번호 및 페이지 크기)
- 검색 결과로 1. 브랜드 검색결과/2. 상품 검색결과/3. 발매정보 검색결과를 반환

611aaad4e37c6d4147296c26f52c1f4d23944d41
- 이전 커밋에서 상품 조회 결과의 각 상품마다 발매정보가 몇 개 있는지 가져오기위해 Item엔티티에 releaseInfo를 @OneToMany 맵핑 했던 것 끊었습니다.

## 참고 사항

## 관련 이슈

- Close #84 
