### PR TITLE
feat: 마이페이지 나의 응모 내역 개수 API 완료

### DIFF
--- a/src/main/java/com/ward/ward_server/api/entry/controller/EntryRecordController.java
+++ b/src/main/java/com/ward/ward_server/api/entry/controller/EntryRecordController.java
@@ -1,5 +1,6 @@
 package com.ward.ward_server.api.entry.controller;
 
+import com.ward.ward_server.api.entry.dto.EntryCountResponse;
 import com.ward.ward_server.api.entry.dto.EntryRecordRequest;
 import com.ward.ward_server.api.entry.dto.EntryRecordResponse;
 import com.ward.ward_server.api.entry.service.EntryRecordService;
@@ -22,6 +23,11 @@ public class EntryRecordController {
     public ApiResponse<EntryRecordResponse> createEntryRecord(@AuthenticationPrincipal CustomUserDetails principal,
                                                               @RequestBody EntryRecordRequest request) {
         return ApiResponse.ok(ENTRY_RECORD_CREATE_SUCCESS, entryRecordService.createEntryRecord(principal.getUserId(), request.releaseInfoId()));
+    }
+
+    @GetMapping("/count")
+    public ApiResponse<EntryCountResponse> getEntryCounts(@AuthenticationPrincipal CustomUserDetails principal) {
+        return ApiResponse.ok(ENTRY_COUNTS_FETCH_SUCCESS, entryRecordService.getEntryCounts(principal.getUserId()));
     }
 
     @GetMapping("/release-infos/{releaseInfoId}")

--- a/src/main/java/com/ward/ward_server/api/entry/dto/EntryCountResponse.java
+++ b/src/main/java/com/ward/ward_server/api/entry/dto/EntryCountResponse.java
@@ -1,0 +1,9 @@
+package com.ward.ward_server.api.entry.dto;
+
+public record EntryCountResponse(
+        long total,
+        long inProgress, // 진행
+        long announcement, // 당첨자 발표
+        long closed // 종료
+) {
+}

--- a/src/main/java/com/ward/ward_server/api/entry/repository/EntryRecordRepository.java
+++ b/src/main/java/com/ward/ward_server/api/entry/repository/EntryRecordRepository.java
@@ -6,9 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 @Repository
 public interface EntryRecordRepository extends JpaRepository<EntryRecord, Long> {
@@ -18,4 +16,16 @@ public interface EntryRecordRepository extends JpaRepository<EntryRecord, Long> 
     void deleteByUserIdAndReleaseInfoId(long userId, long releaseInfoId);
 
     Optional<EntryRecord> findByUserIdAndReleaseInfoId(long userId, long releaseInfoId);
+
+    @Query("SELECT COUNT(e) FROM EntryRecord e WHERE e.user.id = :userId")
+    long countByUserId(@Param("userId") long userId);
+
+    @Query("SELECT COUNT(e) FROM EntryRecord e WHERE e.user.id = :userId AND e.releaseInfo.dueDate > CURRENT_TIMESTAMP")
+    long countInProgressByUserId(@Param("userId") long userId);
+
+    @Query("SELECT COUNT(e) FROM EntryRecord e WHERE e.user.id = :userId AND e.releaseInfo.presentationDate <= CURRENT_TIMESTAMP")
+    long countAnnouncementByUserId(@Param("userId") long userId);
+
+    @Query("SELECT COUNT(e) FROM EntryRecord e WHERE e.user.id = :userId AND e.releaseInfo.dueDate <= CURRENT_TIMESTAMP AND e.releaseInfo.presentationDate > CURRENT_TIMESTAMP")
+    long countClosedByUserId(@Param("userId") long userId);
 }

--- a/src/main/java/com/ward/ward_server/api/entry/service/EntryRecordService.java
+++ b/src/main/java/com/ward/ward_server/api/entry/service/EntryRecordService.java
@@ -1,9 +1,9 @@
 package com.ward.ward_server.api.entry.service;
 
+import com.ward.ward_server.api.entry.dto.EntryCountResponse;
 import com.ward.ward_server.api.entry.dto.EntryRecordResponse;
 import com.ward.ward_server.api.entry.entity.EntryRecord;
 import com.ward.ward_server.api.entry.repository.EntryRecordRepository;
-import com.ward.ward_server.api.releaseInfo.entity.DrawPlatform;
 import com.ward.ward_server.api.releaseInfo.entity.ReleaseInfo;
 import com.ward.ward_server.api.releaseInfo.repository.DrawPlatformRepository;
 import com.ward.ward_server.api.releaseInfo.repository.ReleaseInfoRepository;
@@ -43,6 +43,16 @@ public class EntryRecordService {
         return entryRecord.map(record -> new EntryRecordResponse(true, record.getEntryDate())).orElseGet(() -> new EntryRecordResponse(false, null));
     }
 
+    @Transactional(readOnly = true)
+    public EntryCountResponse getEntryCounts(Long userId) {
+        long total = entryRecordRepository.countByUserId(userId);
+        long inProgress = entryRecordRepository.countInProgressByUserId(userId); // 진행
+        long announcement = entryRecordRepository.countAnnouncementByUserId(userId); // 당첨자 발표
+        long closed = entryRecordRepository.countClosedByUserId(userId); // 마감
+
+        return new EntryCountResponse(total, inProgress, announcement, closed);
+    }
+
     @Transactional
     public void deleteEntryRecord(Long userId, Long releaseInfoId) {
         if (!entryRecordRepository.existsByUserIdAndReleaseInfoId(userId, releaseInfoId)) {
@@ -50,4 +60,6 @@ public class EntryRecordService {
         }
         entryRecordRepository.deleteByUserIdAndReleaseInfoId(userId, releaseInfoId);
     }
+
+
 }

--- a/src/main/java/com/ward/ward_server/api/item/controller/WebCrawlingController.java
+++ b/src/main/java/com/ward/ward_server/api/item/controller/WebCrawlingController.java
@@ -1,21 +1,14 @@
 package com.ward.ward_server.api.item.controller;
 
-import com.ward.ward_server.api.item.service.WebCrawlingService;
-import com.ward.ward_server.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
-
-import static com.ward.ward_server.global.response.ApiResponseMessage.WEBCRAWLING_KASINA_SUCCESS;
-import static com.ward.ward_server.global.response.ApiResponseMessage.WEBCRAWLING_NIKE_SUCCESS;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/wc")
 public class WebCrawlingController {
+    //TODO 선착순 크롤링 시 발매일,마감일,당첨자 발표일 동일하게 입력 필수
 //    private final WebCrawlingService webCrawlingService;
 //
 //    @GetMapping("/nike")

--- a/src/main/java/com/ward/ward_server/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/ward/ward_server/global/config/WebSecurityConfig.java
@@ -43,7 +43,7 @@ public class WebSecurityConfig {
 
                     // User endpoints
                     authorize
-                            .requestMatchers("/items/details").hasAnyRole("USER", "ADMIN")
+                            .requestMatchers("/items/details", "/entry-records/count").hasAnyRole("USER", "ADMIN")
                             .requestMatchers(HttpMethod.GET,"/items/{section}/home").hasAnyRole("USER", "ADMIN")
                             .requestMatchers(HttpMethod.GET, "/items/{section}").hasAnyRole("USER", "ADMIN");
 

--- a/src/main/java/com/ward/ward_server/global/response/ApiResponseMessage.java
+++ b/src/main/java/com/ward/ward_server/global/response/ApiResponseMessage.java
@@ -48,7 +48,7 @@ public enum ApiResponseMessage {
     ENTRY_RECORD_CREATE_SUCCESS("응모 등록에 성공하였습니다."),
     ENTRY_RECORD_DELETE_SUCCESS("응모 삭제에 성공하였습니다."),
     ENTRY_RECORD_LOAD_SUCCESS("응모 조회에 성공하였습니다."),
-    ENTRY_RECORD_BY_USER_LOAD_SUCCESS("회원의 발매정보와 응모 조회에 성공하였습니다."),
+    ENTRY_COUNTS_FETCH_SUCCESS("응모 내역 개수 조회에 성공하였습니다."),
     //관심상품
     WISH_ITEM_CREATE_SUCCESS("관심상품 등록에 성공하였습니다"),
     WISH_ITEM_LOAD_SUCCESS("회원의 관심상품 목록 조회에 성공하였습니다"),


### PR DESCRIPTION
## 요약
마이페이지 나의 응모내역 개수 API 개발

## 작업 내용
응모 개수(전체/진행/당첨자발표/종료) 응답합니다.

## 참고 사항
EntryRecordRepository 에서 발매일, 종료일, 당첨자발표일을 다 활용함으로 선착순 발매 정보 등록 시 3개 일자를 모두 동일하게 필수 입력해야합니다.

## 관련 이슈

- Close #이슈번호
