### PR TITLE
feat: 응모 내역 조회 API 개발(전체/진행/종료/당첨자발표)

### DIFF
--- a/src/main/java/com/ward/ward_server/api/entry/controller/EntryRecordController.java
+++ b/src/main/java/com/ward/ward_server/api/entry/controller/EntryRecordController.java
@@ -1,12 +1,16 @@
 package com.ward.ward_server.api.entry.controller;
 
 import com.ward.ward_server.api.entry.dto.EntryCountResponse;
+import com.ward.ward_server.api.entry.dto.EntryDetailResponse;
 import com.ward.ward_server.api.entry.dto.EntryRecordRequest;
 import com.ward.ward_server.api.entry.dto.EntryRecordResponse;
 import com.ward.ward_server.api.entry.service.EntryRecordService;
 import com.ward.ward_server.api.user.auth.security.CustomUserDetails;
 import com.ward.ward_server.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -41,5 +45,12 @@ public class EntryRecordController {
                                                @PathVariable("releaseInfoId") Long releaseInfoId) {
         entryRecordService.deleteEntryRecord(principal.getUserId(), releaseInfoId);
         return ApiResponse.ok(ENTRY_RECORD_DELETE_SUCCESS);
+    }
+
+    @GetMapping
+    public ApiResponse<Page<EntryDetailResponse>> getEntryRecords(@AuthenticationPrincipal CustomUserDetails principal,
+                                                                  @RequestParam("status") String status,
+                                                                  @PageableDefault(size = 20) Pageable pageable) {
+        return ApiResponse.ok(ENTRY_RECORD_LOAD_SUCCESS, entryRecordService.getEntryRecordsByStatus(principal.getUserId(), status, pageable));
     }
 }

--- a/src/main/java/com/ward/ward_server/api/entry/dto/EntryDetailResponse.java
+++ b/src/main/java/com/ward/ward_server/api/entry/dto/EntryDetailResponse.java
@@ -1,0 +1,9 @@
+package com.ward.ward_server.api.entry.dto;
+
+public record EntryDetailResponse(
+        String mainImage,
+        String englishName,
+        String koreanName,
+        String code
+) {
+}

--- a/src/main/java/com/ward/ward_server/api/entry/dto/EntryDetailResponse.java
+++ b/src/main/java/com/ward/ward_server/api/entry/dto/EntryDetailResponse.java
@@ -4,6 +4,7 @@ public record EntryDetailResponse(
         String mainImage,
         String englishName,
         String koreanName,
-        String code
+        String code,
+        Long releaseInfoId
 ) {
 }

--- a/src/main/java/com/ward/ward_server/api/entry/repository/EntryRecordRepository.java
+++ b/src/main/java/com/ward/ward_server/api/entry/repository/EntryRecordRepository.java
@@ -32,25 +32,25 @@ public interface EntryRecordRepository extends JpaRepository<EntryRecord, Long> 
     @Query("SELECT COUNT(e) FROM EntryRecord e WHERE e.user.id = :userId AND e.releaseInfo.dueDate <= CURRENT_TIMESTAMP AND e.releaseInfo.presentationDate > CURRENT_TIMESTAMP")
     long countClosedByUserId(@Param("userId") long userId);
 
-    @Query("SELECT new com.ward.ward_server.api.entry.dto.EntryDetailResponse(e.releaseInfo.item.mainImage, e.releaseInfo.drawPlatform.englishName, e.releaseInfo.item.koreanName, e.releaseInfo.item.code) " +
+    @Query("SELECT new com.ward.ward_server.api.entry.dto.EntryDetailResponse(e.releaseInfo.item.mainImage, e.releaseInfo.drawPlatform.englishName, e.releaseInfo.item.koreanName, e.releaseInfo.item.code, e.releaseInfo.id) " +
             "FROM EntryRecord e " +
             "WHERE e.user.id = :userId " +
             "ORDER BY e.id DESC")
     Page<EntryDetailResponse> findAllByUserId(@Param("userId") long userId, Pageable pageable);
 
-    @Query("SELECT new com.ward.ward_server.api.entry.dto.EntryDetailResponse(e.releaseInfo.item.mainImage, e.releaseInfo.drawPlatform.englishName, e.releaseInfo.item.koreanName, e.releaseInfo.item.code) " +
+    @Query("SELECT new com.ward.ward_server.api.entry.dto.EntryDetailResponse(e.releaseInfo.item.mainImage, e.releaseInfo.drawPlatform.englishName, e.releaseInfo.item.koreanName, e.releaseInfo.item.code, e.releaseInfo.id) " +
             "FROM EntryRecord e " +
             "WHERE e.user.id = :userId AND e.releaseInfo.dueDate > CURRENT_TIMESTAMP " +
             "ORDER BY e.id DESC")
     Page<EntryDetailResponse> findInProgressByUserId(@Param("userId") long userId, Pageable pageable);
 
-    @Query("SELECT new com.ward.ward_server.api.entry.dto.EntryDetailResponse(e.releaseInfo.item.mainImage, e.releaseInfo.drawPlatform.englishName, e.releaseInfo.item.koreanName, e.releaseInfo.item.code) " +
+    @Query("SELECT new com.ward.ward_server.api.entry.dto.EntryDetailResponse(e.releaseInfo.item.mainImage, e.releaseInfo.drawPlatform.englishName, e.releaseInfo.item.koreanName, e.releaseInfo.item.code, e.releaseInfo.id) " +
             "FROM EntryRecord e " +
             "WHERE e.user.id = :userId AND e.releaseInfo.presentationDate <= CURRENT_TIMESTAMP " +
             "ORDER BY e.id DESC")
     Page<EntryDetailResponse> findAnnouncementByUserId(@Param("userId") long userId, Pageable pageable);
 
-    @Query("SELECT new com.ward.ward_server.api.entry.dto.EntryDetailResponse(e.releaseInfo.item.mainImage, e.releaseInfo.drawPlatform.englishName, e.releaseInfo.item.koreanName, e.releaseInfo.item.code) " +
+    @Query("SELECT new com.ward.ward_server.api.entry.dto.EntryDetailResponse(e.releaseInfo.item.mainImage, e.releaseInfo.drawPlatform.englishName, e.releaseInfo.item.koreanName, e.releaseInfo.item.code, e.releaseInfo.id) " +
             "FROM EntryRecord e " +
             "WHERE e.user.id = :userId AND e.releaseInfo.dueDate <= CURRENT_TIMESTAMP AND e.releaseInfo.presentationDate > CURRENT_TIMESTAMP " +
             "ORDER BY e.id DESC")

--- a/src/main/java/com/ward/ward_server/api/entry/repository/EntryRecordRepository.java
+++ b/src/main/java/com/ward/ward_server/api/entry/repository/EntryRecordRepository.java
@@ -1,6 +1,9 @@
 package com.ward.ward_server.api.entry.repository;
 
+import com.ward.ward_server.api.entry.dto.EntryDetailResponse;
 import com.ward.ward_server.api.entry.entity.EntryRecord;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -28,4 +31,29 @@ public interface EntryRecordRepository extends JpaRepository<EntryRecord, Long> 
 
     @Query("SELECT COUNT(e) FROM EntryRecord e WHERE e.user.id = :userId AND e.releaseInfo.dueDate <= CURRENT_TIMESTAMP AND e.releaseInfo.presentationDate > CURRENT_TIMESTAMP")
     long countClosedByUserId(@Param("userId") long userId);
+
+    @Query("SELECT new com.ward.ward_server.api.entry.dto.EntryDetailResponse(e.releaseInfo.item.mainImage, e.releaseInfo.drawPlatform.englishName, e.releaseInfo.item.koreanName, e.releaseInfo.item.code) " +
+            "FROM EntryRecord e " +
+            "WHERE e.user.id = :userId " +
+            "ORDER BY e.id DESC")
+    Page<EntryDetailResponse> findAllByUserId(@Param("userId") long userId, Pageable pageable);
+
+    @Query("SELECT new com.ward.ward_server.api.entry.dto.EntryDetailResponse(e.releaseInfo.item.mainImage, e.releaseInfo.drawPlatform.englishName, e.releaseInfo.item.koreanName, e.releaseInfo.item.code) " +
+            "FROM EntryRecord e " +
+            "WHERE e.user.id = :userId AND e.releaseInfo.dueDate > CURRENT_TIMESTAMP " +
+            "ORDER BY e.id DESC")
+    Page<EntryDetailResponse> findInProgressByUserId(@Param("userId") long userId, Pageable pageable);
+
+    @Query("SELECT new com.ward.ward_server.api.entry.dto.EntryDetailResponse(e.releaseInfo.item.mainImage, e.releaseInfo.drawPlatform.englishName, e.releaseInfo.item.koreanName, e.releaseInfo.item.code) " +
+            "FROM EntryRecord e " +
+            "WHERE e.user.id = :userId AND e.releaseInfo.presentationDate <= CURRENT_TIMESTAMP " +
+            "ORDER BY e.id DESC")
+    Page<EntryDetailResponse> findAnnouncementByUserId(@Param("userId") long userId, Pageable pageable);
+
+    @Query("SELECT new com.ward.ward_server.api.entry.dto.EntryDetailResponse(e.releaseInfo.item.mainImage, e.releaseInfo.drawPlatform.englishName, e.releaseInfo.item.koreanName, e.releaseInfo.item.code) " +
+            "FROM EntryRecord e " +
+            "WHERE e.user.id = :userId AND e.releaseInfo.dueDate <= CURRENT_TIMESTAMP AND e.releaseInfo.presentationDate > CURRENT_TIMESTAMP " +
+            "ORDER BY e.id DESC")
+    Page<EntryDetailResponse> findClosedByUserId(@Param("userId") long userId, Pageable pageable);
+
 }

--- a/src/main/java/com/ward/ward_server/api/entry/service/EntryRecordService.java
+++ b/src/main/java/com/ward/ward_server/api/entry/service/EntryRecordService.java
@@ -6,7 +6,6 @@ import com.ward.ward_server.api.entry.dto.EntryRecordResponse;
 import com.ward.ward_server.api.entry.entity.EntryRecord;
 import com.ward.ward_server.api.entry.repository.EntryRecordRepository;
 import com.ward.ward_server.api.releaseInfo.entity.ReleaseInfo;
-import com.ward.ward_server.api.releaseInfo.repository.DrawPlatformRepository;
 import com.ward.ward_server.api.releaseInfo.repository.ReleaseInfoRepository;
 import com.ward.ward_server.api.user.entity.User;
 import com.ward.ward_server.api.user.repository.UserRepository;
@@ -25,7 +24,6 @@ import static com.ward.ward_server.global.exception.ExceptionCode.*;
 @RequiredArgsConstructor
 public class EntryRecordService {
     private final EntryRecordRepository entryRecordRepository;
-    private final DrawPlatformRepository drawPlatformRepository;
     private final ReleaseInfoRepository releaseInfoRepository;
     private final UserRepository userRepository;
 
@@ -66,17 +64,12 @@ public class EntryRecordService {
 
     @Transactional(readOnly = true)
     public Page<EntryDetailResponse> getEntryRecordsByStatus(Long userId, String status, Pageable pageable) {
-        switch (status) {
-            case "in-progress":
-                return entryRecordRepository.findInProgressByUserId(userId, pageable);
-            case "announcement":
-                return entryRecordRepository.findAnnouncementByUserId(userId, pageable);
-            case "closed":
-                return entryRecordRepository.findClosedByUserId(userId, pageable);
-            case "all":
-            default:
-                return entryRecordRepository.findAllByUserId(userId, pageable);
-        }
+        return switch (status) {
+            case "in-progress" -> entryRecordRepository.findInProgressByUserId(userId, pageable);
+            case "announcement" -> entryRecordRepository.findAnnouncementByUserId(userId, pageable);
+            case "closed" -> entryRecordRepository.findClosedByUserId(userId, pageable);
+            default -> entryRecordRepository.findAllByUserId(userId, pageable);
+        };
     }
 
 }

--- a/src/main/java/com/ward/ward_server/api/entry/service/EntryRecordService.java
+++ b/src/main/java/com/ward/ward_server/api/entry/service/EntryRecordService.java
@@ -22,6 +22,7 @@ import static com.ward.ward_server.global.exception.ExceptionCode.*;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class EntryRecordService {
     private final EntryRecordRepository entryRecordRepository;
     private final ReleaseInfoRepository releaseInfoRepository;
@@ -38,13 +39,11 @@ public class EntryRecordService {
         return new EntryRecordResponse(true, savedEntryRecord.getEntryDate());
     }
 
-    @Transactional(readOnly = true)
     public EntryRecordResponse getEntryRecordByReleaseInfo(Long userId, Long releaseInfoId) {
         Optional<EntryRecord> entryRecord = entryRecordRepository.findByUserIdAndReleaseInfoId(userId, releaseInfoId);
         return entryRecord.map(record -> new EntryRecordResponse(true, record.getEntryDate())).orElseGet(() -> new EntryRecordResponse(false, null));
     }
 
-    @Transactional(readOnly = true)
     public EntryCountResponse getEntryCounts(Long userId) {
         long total = entryRecordRepository.countByUserId(userId);
         long inProgress = entryRecordRepository.countInProgressByUserId(userId); // 진행
@@ -62,7 +61,6 @@ public class EntryRecordService {
         entryRecordRepository.deleteByUserIdAndReleaseInfoId(userId, releaseInfoId);
     }
 
-    @Transactional(readOnly = true)
     public Page<EntryDetailResponse> getEntryRecordsByStatus(Long userId, String status, Pageable pageable) {
         return switch (status) {
             case "in-progress" -> entryRecordRepository.findInProgressByUserId(userId, pageable);

--- a/src/main/java/com/ward/ward_server/api/entry/service/EntryRecordService.java
+++ b/src/main/java/com/ward/ward_server/api/entry/service/EntryRecordService.java
@@ -1,6 +1,7 @@
 package com.ward.ward_server.api.entry.service;
 
 import com.ward.ward_server.api.entry.dto.EntryCountResponse;
+import com.ward.ward_server.api.entry.dto.EntryDetailResponse;
 import com.ward.ward_server.api.entry.dto.EntryRecordResponse;
 import com.ward.ward_server.api.entry.entity.EntryRecord;
 import com.ward.ward_server.api.entry.repository.EntryRecordRepository;
@@ -11,6 +12,8 @@ import com.ward.ward_server.api.user.entity.User;
 import com.ward.ward_server.api.user.repository.UserRepository;
 import com.ward.ward_server.global.exception.ApiException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -61,5 +64,19 @@ public class EntryRecordService {
         entryRecordRepository.deleteByUserIdAndReleaseInfoId(userId, releaseInfoId);
     }
 
+    @Transactional(readOnly = true)
+    public Page<EntryDetailResponse> getEntryRecordsByStatus(Long userId, String status, Pageable pageable) {
+        switch (status) {
+            case "in-progress":
+                return entryRecordRepository.findInProgressByUserId(userId, pageable);
+            case "announcement":
+                return entryRecordRepository.findAnnouncementByUserId(userId, pageable);
+            case "closed":
+                return entryRecordRepository.findClosedByUserId(userId, pageable);
+            case "all":
+            default:
+                return entryRecordRepository.findAllByUserId(userId, pageable);
+        }
+    }
 
 }

--- a/src/main/java/com/ward/ward_server/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/ward/ward_server/global/config/WebSecurityConfig.java
@@ -44,6 +44,7 @@ public class WebSecurityConfig {
                     // User endpoints
                     authorize
                             .requestMatchers("/items/details", "/entry-records/count").hasAnyRole("USER", "ADMIN")
+                            .requestMatchers(HttpMethod.GET,"/entry-records").hasAnyRole("USER", "ADMIN")
                             .requestMatchers(HttpMethod.GET,"/items/{section}/home").hasAnyRole("USER", "ADMIN")
                             .requestMatchers(HttpMethod.GET, "/items/{section}").hasAnyRole("USER", "ADMIN");
 


### PR DESCRIPTION
## 요약
1. 응모 내역 조회 API 개발
2. 코드 정리

## 작업 내용
[2a74066](https://github.com/Ward-Group/Ward_Server/pull/94/commits/2a7406679d6c40af5d187c93f219e1f9c334f90a)
무한 스크롤 위해 페이징처리
파라미터로 전체/진행/종료/당첨자발표를 status로 받아서 서비스단에서 분리해서 처리

[f520e97](https://github.com/Ward-Group/Ward_Server/pull/94/commits/f520e976cbbf50d6f024d8d7937c04fb3bc0d202)
미사용 의존성 제거, switch문 개선

[9e46358](https://github.com/Ward-Group/Ward_Server/pull/94/commits/9e463581c76b6ea5390b1fb37fb58679629d5aaf)
응답값에 발매정보id 추가

[c78c0b9](https://github.com/Ward-Group/Ward_Server/pull/94/commits/c78c0b923fd1e78e479a3084711177192e6bc16e)
Service 클래스 전체에 @Transactional(readOnly=true) 어노테이션 적용 -> 필요한 곳에만 @Transactional 적용

## 참고 사항

## 관련 이슈

- Close #95
