### PR TITLE
feat: 마감 임박 상품 API 추가

### DIFF
--- a/src/main/java/com/ward/ward_server/api/releaseInfo/controller/PublicReleaseInfoController.java
+++ b/src/main/java/com/ward/ward_server/api/releaseInfo/controller/PublicReleaseInfoController.java
@@ -1,6 +1,7 @@
 package com.ward.ward_server.api.releaseInfo.controller;
 
 import com.ward.ward_server.api.item.entity.enums.Category;
+import com.ward.ward_server.api.releaseInfo.dto.ExpiringItemResponse;
 import com.ward.ward_server.api.releaseInfo.dto.ReleaseInfoDetailResponse;
 import com.ward.ward_server.api.releaseInfo.dto.ReleaseInfoSimpleResponse;
 import com.ward.ward_server.api.releaseInfo.entity.ReleaseInfo;
@@ -18,7 +19,8 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-import static com.ward.ward_server.global.response.ApiResponseMessage.*;
+import static com.ward.ward_server.global.response.ApiResponseMessage.RELEASE_INFO_DETAIL_LOAD_SUCCESS;
+import static com.ward.ward_server.global.response.ApiResponseMessage.RELEASE_INFO_LIST_LOAD_SUCCESS;
 
 @RestController
 @RequiredArgsConstructor
@@ -62,5 +64,11 @@ public class PublicReleaseInfoController {
             throw new IllegalArgumentException("Invalid status: " + status);
         }
         return ApiResponse.ok(releaseInfos);
+    }
+
+    @GetMapping("/expiring-items")
+    public ApiResponse<List<ExpiringItemResponse>> getExpiringItems() {
+        List<ExpiringItemResponse> items = releaseInfoService.getExpiringItems(10);
+        return ApiResponse.ok(RELEASE_INFO_LIST_LOAD_SUCCESS, items);
     }
 }

--- a/src/main/java/com/ward/ward_server/api/releaseInfo/dto/ExpiringItemResponse.java
+++ b/src/main/java/com/ward/ward_server/api/releaseInfo/dto/ExpiringItemResponse.java
@@ -1,0 +1,7 @@
+package com.ward.ward_server.api.releaseInfo.dto;
+
+public record ExpiringItemResponse(
+        long itemId,
+        String itemMainImage
+) {
+}

--- a/src/main/java/com/ward/ward_server/api/releaseInfo/repository/ReleaseInfoRepository.java
+++ b/src/main/java/com/ward/ward_server/api/releaseInfo/repository/ReleaseInfoRepository.java
@@ -1,6 +1,7 @@
 package com.ward.ward_server.api.releaseInfo.repository;
 
 import com.ward.ward_server.api.item.entity.Item;
+import com.ward.ward_server.api.releaseInfo.dto.ExpiringItemResponse;
 import com.ward.ward_server.api.releaseInfo.entity.DrawPlatform;
 import com.ward.ward_server.api.releaseInfo.entity.ReleaseInfo;
 import com.ward.ward_server.api.releaseInfo.repository.query.ReleaseInfoQueryRepository;
@@ -37,10 +38,11 @@ public interface ReleaseInfoRepository extends JpaRepository<ReleaseInfo, Long>,
             "OR LOWER(dp.englishName) LIKE LOWER(CONCAT('%', :keyword, '%'))")
     Page<ReleaseInfo> searchReleaseInfos(@Param("keyword") String keyword, Pageable pageable);
 
-    @Query("SELECT DISTINCT r.item.id, r.item.mainImage, MIN(r.dueDate) as dueDate " +
+    @Query("SELECT new com.ward.ward_server.api.releaseInfo.dto.ExpiringItemResponse(r.item.id, r.item.mainImage, MIN(r.dueDate) as dueDate) " +
             "FROM ReleaseInfo r " +
             "WHERE r.dueDate > :now " +
             "GROUP BY r.item.id, r.item.mainImage " +
             "ORDER BY dueDate ASC")
-    List<Object[]> findExpiringItems(@Param("now") LocalDateTime now, Pageable pageable);
+    List<ExpiringItemResponse> findExpiringItems(@Param("now") LocalDateTime now, Pageable pageable);
+
 }

--- a/src/main/java/com/ward/ward_server/api/releaseInfo/repository/ReleaseInfoRepository.java
+++ b/src/main/java/com/ward/ward_server/api/releaseInfo/repository/ReleaseInfoRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public interface ReleaseInfoRepository extends JpaRepository<ReleaseInfo, Long>, ReleaseInfoQueryRepository {
 
@@ -35,4 +36,11 @@ public interface ReleaseInfoRepository extends JpaRepository<ReleaseInfo, Long>,
             "OR LOWER(dp.koreanName) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
             "OR LOWER(dp.englishName) LIKE LOWER(CONCAT('%', :keyword, '%'))")
     Page<ReleaseInfo> searchReleaseInfos(@Param("keyword") String keyword, Pageable pageable);
+
+    @Query("SELECT DISTINCT r.item.id, r.item.mainImage, MIN(r.dueDate) as dueDate " +
+            "FROM ReleaseInfo r " +
+            "WHERE r.dueDate > :now " +
+            "GROUP BY r.item.id, r.item.mainImage " +
+            "ORDER BY dueDate ASC")
+    List<Object[]> findExpiringItems(@Param("now") LocalDateTime now, Pageable pageable);
 }

--- a/src/main/java/com/ward/ward_server/api/releaseInfo/repository/ReleaseInfoRepository.java
+++ b/src/main/java/com/ward/ward_server/api/releaseInfo/repository/ReleaseInfoRepository.java
@@ -38,11 +38,10 @@ public interface ReleaseInfoRepository extends JpaRepository<ReleaseInfo, Long>,
             "OR LOWER(dp.englishName) LIKE LOWER(CONCAT('%', :keyword, '%'))")
     Page<ReleaseInfo> searchReleaseInfos(@Param("keyword") String keyword, Pageable pageable);
 
-    @Query("SELECT new com.ward.ward_server.api.releaseInfo.dto.ExpiringItemResponse(r.item.id, r.item.mainImage, MIN(r.dueDate) as dueDate) " +
+    @Query("SELECT new com.ward.ward_server.api.releaseInfo.dto.ExpiringItemResponse(r.item.id, r.item.mainImage) " +
             "FROM ReleaseInfo r " +
             "WHERE r.dueDate > :now " +
             "GROUP BY r.item.id, r.item.mainImage " +
-            "ORDER BY dueDate ASC")
+            "ORDER BY MIN(r.dueDate) ASC")
     List<ExpiringItemResponse> findExpiringItems(@Param("now") LocalDateTime now, Pageable pageable);
-
 }

--- a/src/main/java/com/ward/ward_server/api/releaseInfo/service/ReleaseInfoService.java
+++ b/src/main/java/com/ward/ward_server/api/releaseInfo/service/ReleaseInfoService.java
@@ -4,6 +4,7 @@ import com.ward.ward_server.api.item.entity.Brand;
 import com.ward.ward_server.api.item.entity.Item;
 import com.ward.ward_server.api.item.entity.enums.Category;
 import com.ward.ward_server.api.item.repository.ItemRepository;
+import com.ward.ward_server.api.releaseInfo.dto.ExpiringItemResponse;
 import com.ward.ward_server.api.releaseInfo.dto.ReleaseInfoDetailResponse;
 import com.ward.ward_server.api.releaseInfo.dto.ReleaseInfoSimpleResponse;
 import com.ward.ward_server.api.releaseInfo.entity.DrawPlatform;
@@ -20,12 +21,14 @@ import com.ward.ward_server.global.exception.ApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.ward.ward_server.global.Object.Constants.API_PAGE_SIZE;
 import static com.ward.ward_server.global.exception.ExceptionCode.*;
@@ -192,5 +195,19 @@ public class ReleaseInfoService {
                 releaseInfo.getReleaseFormatDate(), releaseInfo.getDueFormatDate(), releaseInfo.getPresentationFormatDate(),
                 releaseInfo.getReleasePrice(), releaseInfo.getCurrencyUnit().toString(),
                 releaseInfo.getNotificationMethod().getDesc(), releaseInfo.getReleaseMethod().getDesc(), releaseInfo.getDeliveryMethod().getDesc());
+    }
+
+    @Transactional(readOnly = true)
+    public List<ExpiringItemResponse> getExpiringItems(int limit) {
+        LocalDateTime now = LocalDateTime.now();
+        Pageable pageable = PageRequest.of(0, limit);
+
+        List<Object[]> results = releaseInfoRepository.findExpiringItems(now, pageable);
+
+        return results.stream()
+                .map(result -> new ExpiringItemResponse(
+                        (Long) result[0],
+                        (String) result[1]))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/ward/ward_server/api/releaseInfo/service/ReleaseInfoService.java
+++ b/src/main/java/com/ward/ward_server/api/releaseInfo/service/ReleaseInfoService.java
@@ -28,7 +28,6 @@ import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.ward.ward_server.global.Object.Constants.API_PAGE_SIZE;
 import static com.ward.ward_server.global.exception.ExceptionCode.*;
@@ -202,12 +201,6 @@ public class ReleaseInfoService {
         LocalDateTime now = LocalDateTime.now();
         Pageable pageable = PageRequest.of(0, limit);
 
-        List<Object[]> results = releaseInfoRepository.findExpiringItems(now, pageable);
-
-        return results.stream()
-                .map(result -> new ExpiringItemResponse(
-                        (Long) result[0],
-                        (String) result[1]))
-                .collect(Collectors.toList());
+        return releaseInfoRepository.findExpiringItems(now, pageable);
     }
 }


### PR DESCRIPTION
## 요약
마감 임박 상품 API 개발
- get 요청
- 응답: 1)itemId, 2)itemMainImage

## 작업 내용
- ExpiringItemResponse DTO 추가
- ReleaseInfoRepository에 findExpiringItems 쿼리 메소드 추가
- ReleaseInfoService에 getExpiringItems 서비스 메소드 추가
- PublicReleaseInfoController에 마감 임박 상품 엔드포인트 추가

마감 시간이 가까운 순으로 상품을 반환하는 API를 구현하였습니다.
각 상품은 중복을 제거하고, 아이템 ID와 메인 이미지만 응답에 포함하도록 하였습니다.

## 참고 사항

## 관련 이슈

- Close #이슈번호
